### PR TITLE
feat: auto-sync prod and local DB on npm run dev start/stop

### DIFF
--- a/app/api/db-sync/route.ts
+++ b/app/api/db-sync/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifySession } from '@/lib/auth/session';
-import { Client } from 'pg';
 import {
   TABLES,
   computeDiffs,
   syncDirection,
+  pushMissing,
   withClients,
-  stripQuotes,
   type SyncResult,
 } from '@/lib/db/sync-core';
 
@@ -36,10 +35,6 @@ function ensureProdConfigured(): NextResponse | null {
   return null;
 }
 
-function callWithClients<T>(fn: (prod: Client, local: Client) => Promise<T>): Promise<T> {
-  return withClients(process.env.PROD_DATABASE_URL!, process.env.DATABASE_URL!, fn);
-}
-
 export async function GET(request: NextRequest) {
   const authError = await requireSession(request);
   if (authError) return authError;
@@ -48,7 +43,11 @@ export async function GET(request: NextRequest) {
   if (configError) return configError;
 
   try {
-    const diffs = await callWithClients(computeDiffs);
+    const diffs = await withClients(
+      process.env.PROD_DATABASE_URL!,
+      process.env.DATABASE_URL!,
+      computeDiffs
+    );
     return NextResponse.json({ diffs });
   } catch (error) {
     console.error('[db-sync] status error:', error);
@@ -77,27 +76,26 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const results = await callWithClients(async (prod, local) => {
-      const syncResults: SyncResult[] = [];
+    const results = await withClients(
+      process.env.PROD_DATABASE_URL!,
+      process.env.DATABASE_URL!,
+      async (prod, local) => {
+        const syncResults: SyncResult[] = [];
 
-      if (direction === 'pull' || direction === 'full') {
-        for (const table of TABLES) {
-          syncResults.push(await syncDirection(prod, local, table, 'prod -> local'));
-        }
-      }
-
-      if (direction === 'push' || direction === 'full') {
-        const diffs = await computeDiffs(prod, local);
-        for (const table of TABLES) {
-          const diff = diffs.find(d => d.table === stripQuotes(table.name));
-          if (diff && diff.onlyLocal.length > 0) {
-            syncResults.push(await syncDirection(local, prod, table, 'local -> prod'));
+        if (direction === 'pull' || direction === 'full') {
+          for (const table of TABLES) {
+            syncResults.push(await syncDirection(prod, local, table, 'prod -> local'));
           }
         }
-      }
 
-      return syncResults;
-    });
+        if (direction === 'push' || direction === 'full') {
+          const diffs = await computeDiffs(prod, local);
+          syncResults.push(...await pushMissing(prod, local, diffs));
+        }
+
+        return syncResults;
+      }
+    );
 
     return NextResponse.json({ success: true, results });
   } catch (error) {

--- a/app/api/db-sync/route.ts
+++ b/app/api/db-sync/route.ts
@@ -1,159 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifySession } from '@/lib/auth/session';
 import { Client } from 'pg';
+import {
+  TABLES,
+  computeDiffs,
+  syncDirection,
+  withClients,
+  stripQuotes,
+  type SyncResult,
+} from '@/lib/db/sync-core';
 
 export const dynamic = 'force-dynamic';
-
-interface TableConfig {
-  name: string;
-  conflictKey: string;
-  orderBy: string;
-  identityCol: string;
-}
-
-const TABLES: TableConfig[] = [
-  { name: '"Book"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"' },
-  { name: '"BookImage"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"' },
-  { name: '"ProcessingHistory"', conflictKey: 'id', orderBy: '"processedAt"', identityCol: 'id' },
-  { name: 'bookmarks', conflictKey: 'id', orderBy: 'updated_at', identityCol: 'file_name' },
-  { name: '"UserBookmark"', conflictKey: 'id', orderBy: '"updatedAt"', identityCol: 'id' },
-  { name: 'vocabulary_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'word' },
-  { name: 'text_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'file_name' },
-];
-
-function stripQuotes(name: string): string {
-  return name.replace(/^"|"$/g, '');
-}
-
-function quoteIdent(name: string): string {
-  return `"${name}"`;
-}
-
-async function getColumns(client: Client, tableName: string): Promise<string[]> {
-  const bare = stripQuotes(tableName);
-  const result = await client.query(
-    `SELECT column_name FROM information_schema.columns
-     WHERE table_name = $1 AND table_schema = 'public'
-     ORDER BY ordinal_position`,
-    [bare]
-  );
-  return result.rows.map((r: { column_name: string }) => r.column_name);
-}
-
-async function getCount(client: Client, table: string): Promise<number> {
-  const bare = stripQuotes(table);
-  try {
-    const result = await client.query(`SELECT COUNT(*) as count FROM "${bare}"`);
-    return parseInt(result.rows[0].count, 10);
-  } catch {
-    return -1;
-  }
-}
-
-async function getIdentities(client: Client, table: TableConfig): Promise<Set<string>> {
-  const bare = stripQuotes(table.name);
-  try {
-    let query: string;
-    if (bare === 'text_entries' || bare === 'bookmarks') {
-      query = `SELECT file_name || '|' || directory as key FROM "${bare}"`;
-    } else {
-      query = `SELECT ${table.identityCol}::text as key FROM "${bare}"`;
-    }
-    const result = await client.query(query);
-    return new Set(result.rows.map((r: { key: string }) => r.key));
-  } catch {
-    return new Set();
-  }
-}
-
-interface DiffResult {
-  table: string;
-  localCount: number;
-  prodCount: number;
-  onlyLocal: string[];
-  onlyProd: string[];
-}
-
-async function computeDiffs(prod: Client, local: Client): Promise<DiffResult[]> {
-  const diffs: DiffResult[] = [];
-  for (const table of TABLES) {
-    const [localCount, prodCount, localIds, prodIds] = await Promise.all([
-      getCount(local, table.name),
-      getCount(prod, table.name),
-      getIdentities(local, table),
-      getIdentities(prod, table),
-    ]);
-    const onlyLocal = Array.from(localIds).filter(id => !prodIds.has(id));
-    const onlyProd = Array.from(prodIds).filter(id => !localIds.has(id));
-    diffs.push({
-      table: stripQuotes(table.name),
-      localCount,
-      prodCount,
-      onlyLocal,
-      onlyProd,
-    });
-  }
-  return diffs;
-}
-
-async function syncDirection(
-  source: Client,
-  target: Client,
-  table: TableConfig,
-): Promise<number> {
-  const columns = await getColumns(source, table.name);
-  if (columns.length === 0) return 0;
-
-  const sourceRows = await source.query(
-    `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`
-  );
-  if (sourceRows.rows.length === 0) return 0;
-
-  const quotedCols = columns.map(quoteIdent);
-  const colList = quotedCols.join(', ');
-  const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
-  const conflictCol = quoteIdent(table.conflictKey);
-  const updateSet = columns
-    .filter(c => c !== table.conflictKey)
-    .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
-    .join(', ');
-
-  let synced = 0;
-  for (const row of sourceRows.rows) {
-    const values = columns.map(c => row[c]);
-    try {
-      await target.query(
-        `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
-         ON CONFLICT (${conflictCol}) DO UPDATE SET ${updateSet}`,
-        values
-      );
-      synced++;
-    } catch (err) {
-      console.error(`[db-sync] ${table.name}:`, err instanceof Error ? err.message : err);
-    }
-  }
-  return synced;
-}
-
-async function withClients<T>(fn: (prod: Client, local: Client) => Promise<T>): Promise<T> {
-  const prodUrl = process.env.PROD_DATABASE_URL;
-  const localUrl = process.env.DATABASE_URL;
-
-  if (!prodUrl || !localUrl) {
-    throw new Error('PROD_DATABASE_URL or DATABASE_URL not configured');
-  }
-
-  const prod = new Client({ connectionString: prodUrl, ssl: { rejectUnauthorized: false } });
-  const local = new Client({ connectionString: localUrl });
-
-  try {
-    await Promise.all([prod.connect(), local.connect()]);
-    return await fn(prod, local);
-  } finally {
-    await prod.end().catch(() => {});
-    await local.end().catch(() => {});
-  }
-}
 
 async function requireSession(request: NextRequest): Promise<NextResponse | null> {
   const sessionCookie = request.cookies.get('session');
@@ -163,19 +20,35 @@ async function requireSession(request: NextRequest): Promise<NextResponse | null
   return null;
 }
 
-export async function GET(request: NextRequest) {
-  const authError = await requireSession(request);
-  if (authError) return authError;
-
+function ensureProdConfigured(): NextResponse | null {
   if (!process.env.PROD_DATABASE_URL) {
     return NextResponse.json(
       { error: 'Sync not available - PROD_DATABASE_URL not configured' },
       { status: 503 }
     );
   }
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json(
+      { error: 'Sync not available - DATABASE_URL not configured' },
+      { status: 503 }
+    );
+  }
+  return null;
+}
+
+function callWithClients<T>(fn: (prod: Client, local: Client) => Promise<T>): Promise<T> {
+  return withClients(process.env.PROD_DATABASE_URL!, process.env.DATABASE_URL!, fn);
+}
+
+export async function GET(request: NextRequest) {
+  const authError = await requireSession(request);
+  if (authError) return authError;
+
+  const configError = ensureProdConfigured();
+  if (configError) return configError;
 
   try {
-    const diffs = await withClients(computeDiffs);
+    const diffs = await callWithClients(computeDiffs);
     return NextResponse.json({ diffs });
   } catch (error) {
     console.error('[db-sync] status error:', error);
@@ -190,12 +63,8 @@ export async function POST(request: NextRequest) {
   const authError = await requireSession(request);
   if (authError) return authError;
 
-  if (!process.env.PROD_DATABASE_URL) {
-    return NextResponse.json(
-      { error: 'Sync not available - PROD_DATABASE_URL not configured' },
-      { status: 503 }
-    );
-  }
+  const configError = ensureProdConfigured();
+  if (configError) return configError;
 
   const body = await request.json();
   const { direction } = body as { direction: 'pull' | 'push' | 'full' };
@@ -208,13 +77,12 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const results = await withClients(async (prod, local) => {
-      const syncResults: { table: string; rows: number; direction: string }[] = [];
+    const results = await callWithClients(async (prod, local) => {
+      const syncResults: SyncResult[] = [];
 
       if (direction === 'pull' || direction === 'full') {
         for (const table of TABLES) {
-          const rows = await syncDirection(prod, local, table);
-          syncResults.push({ table: stripQuotes(table.name), rows, direction: 'prod -> local' });
+          syncResults.push(await syncDirection(prod, local, table, 'prod -> local'));
         }
       }
 
@@ -223,8 +91,7 @@ export async function POST(request: NextRequest) {
         for (const table of TABLES) {
           const diff = diffs.find(d => d.table === stripQuotes(table.name));
           if (diff && diff.onlyLocal.length > 0) {
-            const rows = await syncDirection(local, prod, table);
-            syncResults.push({ table: stripQuotes(table.name), rows, direction: 'local -> prod' });
+            syncResults.push(await syncDirection(local, prod, table, 'local -> prod'));
           }
         }
       }

--- a/app/library/components/DbSyncModal.tsx
+++ b/app/library/components/DbSyncModal.tsx
@@ -5,8 +5,8 @@ import { API_ROUTES } from '@/lib/constants';
 
 interface DiffResult {
   table: string;
-  localCount: number;
-  prodCount: number;
+  localCount: number | null;
+  prodCount: number | null;
   onlyLocal: string[];
   onlyProd: string[];
 }
@@ -14,6 +14,7 @@ interface DiffResult {
 interface SyncResult {
   table: string;
   rows: number;
+  failed: number;
   direction: string;
 }
 
@@ -72,7 +73,7 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
   const hasLocalOnly = diffs?.some(d => d.onlyLocal.length > 0) ?? false;
   const hasProdOnly = diffs?.some(d => d.onlyProd.length > 0) ?? false;
   const allInSync = diffs !== null && !hasLocalOnly && !hasProdOnly &&
-    diffs.every(d => d.localCount === d.prodCount);
+    diffs.every(d => d.localCount !== null && d.prodCount !== null && d.localCount === d.prodCount);
 
   return (
     <div
@@ -143,7 +144,9 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
                   </thead>
                   <tbody>
                     {diffs.map((d) => {
-                      const inSync = d.onlyLocal.length === 0 && d.onlyProd.length === 0 && d.localCount === d.prodCount;
+                      const countsKnown = d.localCount !== null && d.prodCount !== null;
+                      const inSync = d.onlyLocal.length === 0 && d.onlyProd.length === 0
+                        && countsKnown && d.localCount === d.prodCount;
                       let status = 'In sync';
                       let statusColor = '#34C759';
                       if (d.onlyLocal.length > 0 && d.onlyProd.length > 0) {
@@ -155,6 +158,9 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
                       } else if (d.onlyProd.length > 0) {
                         status = `+${d.onlyProd.length} prod only`;
                         statusColor = '#AF52DE';
+                      } else if (!countsKnown) {
+                        status = 'Count unavailable';
+                        statusColor = '#FF9500';
                       } else if (d.localCount !== d.prodCount) {
                         status = 'Counts differ';
                         statusColor = '#FF9500';
@@ -163,10 +169,10 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
                         <tr key={d.table} className="border-t" style={{ borderColor: '#F2F2F7' }}>
                           <td className="py-2.5 px-3 font-mono text-xs" style={{ color: '#1D1D1F' }}>{d.table}</td>
                           <td className="py-2.5 px-3 text-right tabular-nums" style={{ color: '#1D1D1F' }}>
-                            {d.localCount === -1 ? 'N/A' : d.localCount}
+                            {d.localCount === null ? 'N/A' : d.localCount}
                           </td>
                           <td className="py-2.5 px-3 text-right tabular-nums" style={{ color: '#1D1D1F' }}>
-                            {d.prodCount === -1 ? 'N/A' : d.prodCount}
+                            {d.prodCount === null ? 'N/A' : d.prodCount}
                           </td>
                           <td className="py-2.5 px-3">
                             <span
@@ -193,7 +199,7 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
                   <p className="text-sm font-medium mb-2" style={{ color: '#34C759' }}>Sync completed</p>
                   {syncResults.map((r, i) => (
                     <p key={i} className="text-xs" style={{ color: '#1D1D1F' }}>
-                      {r.table}: {r.rows} rows ({r.direction})
+                      {r.table}: {r.rows} rows ({r.direction}){r.failed > 0 ? `, ${r.failed} failed` : ''}
                     </p>
                   ))}
                 </div>

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -1,21 +1,73 @@
 import { Client } from 'pg';
 
+export type SyncDirection = 'prod -> local' | 'local -> prod';
+
+type IdentityKey =
+  | { kind: 'column'; col: string }
+  | { kind: 'composite'; cols: [string, string]; sep: string };
+
+type ConflictStrategy =
+  | { kind: 'insert-only' }
+  | { kind: 'last-write-wins'; timestampCol: string };
+
 export interface TableConfig {
   name: string;
   conflictKey: string;
   orderBy: string;
-  identityCol: string;
-  timestampCol: string | null;
+  identity: IdentityKey;
+  strategy: ConflictStrategy;
 }
 
 export const TABLES: TableConfig[] = [
-  { name: '"Book"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"', timestampCol: '"updatedAt"' },
-  { name: '"BookImage"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"', timestampCol: null },
-  { name: '"ProcessingHistory"', conflictKey: 'id', orderBy: '"processedAt"', identityCol: 'id', timestampCol: null },
-  { name: 'bookmarks', conflictKey: 'id', orderBy: 'updated_at', identityCol: 'file_name', timestampCol: 'updated_at' },
-  { name: '"UserBookmark"', conflictKey: 'id', orderBy: '"updatedAt"', identityCol: 'id', timestampCol: '"updatedAt"' },
-  { name: 'vocabulary_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'word', timestampCol: 'updated_at' },
-  { name: 'text_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'file_name', timestampCol: null },
+  {
+    name: '"Book"',
+    conflictKey: 'id',
+    orderBy: '"createdAt"',
+    identity: { kind: 'column', col: '"fileName"' },
+    strategy: { kind: 'last-write-wins', timestampCol: '"updatedAt"' },
+  },
+  {
+    name: '"BookImage"',
+    conflictKey: 'id',
+    orderBy: '"createdAt"',
+    identity: { kind: 'column', col: '"fileName"' },
+    strategy: { kind: 'insert-only' },
+  },
+  {
+    name: '"ProcessingHistory"',
+    conflictKey: 'id',
+    orderBy: '"processedAt"',
+    identity: { kind: 'column', col: 'id' },
+    strategy: { kind: 'insert-only' },
+  },
+  {
+    name: 'bookmarks',
+    conflictKey: 'id',
+    orderBy: 'updated_at',
+    identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
+    strategy: { kind: 'last-write-wins', timestampCol: 'updated_at' },
+  },
+  {
+    name: '"UserBookmark"',
+    conflictKey: 'id',
+    orderBy: '"updatedAt"',
+    identity: { kind: 'column', col: 'id' },
+    strategy: { kind: 'last-write-wins', timestampCol: '"updatedAt"' },
+  },
+  {
+    name: 'vocabulary_entries',
+    conflictKey: 'id',
+    orderBy: 'created_at',
+    identity: { kind: 'column', col: 'word' },
+    strategy: { kind: 'last-write-wins', timestampCol: 'updated_at' },
+  },
+  {
+    name: 'text_entries',
+    conflictKey: 'id',
+    orderBy: 'created_at',
+    identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
+    strategy: { kind: 'insert-only' },
+  },
 ];
 
 export function stripQuotes(name: string): string {
@@ -23,7 +75,7 @@ export function stripQuotes(name: string): string {
 }
 
 function quoteIdent(name: string): string {
-  return `"${name}"`;
+  return `"${name.replace(/"/g, '""')}"`;
 }
 
 async function getColumns(client: Client, tableName: string): Promise<string[]> {
@@ -37,33 +89,43 @@ async function getColumns(client: Client, tableName: string): Promise<string[]> 
   return result.rows.map((r: { column_name: string }) => r.column_name);
 }
 
-async function getCount(client: Client, table: string): Promise<number> {
+async function getCount(client: Client, table: string): Promise<number | null> {
   const bare = stripQuotes(table);
   try {
     const result = await client.query(`SELECT COUNT(*) as count FROM "${bare}"`);
     return parseInt(result.rows[0].count, 10);
-  } catch {
-    return -1;
+  } catch (err) {
+    console.error(`[sync-core] getCount(${bare}) failed:`, err instanceof Error ? err.message : err);
+    return null;
   }
 }
 
-async function getIdentities(client: Client, table: TableConfig): Promise<Set<string>> {
+function identityQuery(table: TableConfig): string {
   const bare = stripQuotes(table.name);
+  if (table.identity.kind === 'composite') {
+    const [a, b] = table.identity.cols;
+    return `SELECT ${a} || '${table.identity.sep}' || ${b} as key FROM "${bare}"`;
+  }
+  return `SELECT ${table.identity.col}::text as key FROM "${bare}"`;
+}
+
+async function getIdentities(client: Client, table: TableConfig): Promise<Set<string>> {
   try {
-    const query = (bare === 'text_entries' || bare === 'bookmarks')
-      ? `SELECT file_name || '|' || directory as key FROM "${bare}"`
-      : `SELECT ${table.identityCol}::text as key FROM "${bare}"`;
-    const result = await client.query(query);
+    const result = await client.query(identityQuery(table));
     return new Set(result.rows.map((r: { key: string }) => r.key));
-  } catch {
+  } catch (err) {
+    console.error(
+      `[sync-core] getIdentities(${stripQuotes(table.name)}) failed:`,
+      err instanceof Error ? err.message : err
+    );
     return new Set();
   }
 }
 
 export interface DiffResult {
   table: string;
-  localCount: number;
-  prodCount: number;
+  localCount: number | null;
+  prodCount: number | null;
   onlyLocal: string[];
   onlyProd: string[];
 }
@@ -77,30 +139,28 @@ export async function computeDiffs(prod: Client, local: Client): Promise<DiffRes
       getIdentities(local, table),
       getIdentities(prod, table),
     ]);
-    const onlyLocal = Array.from(localIds).filter(id => !prodIds.has(id));
-    const onlyProd = Array.from(prodIds).filter(id => !localIds.has(id));
     diffs.push({
       table: stripQuotes(table.name),
       localCount,
       prodCount,
-      onlyLocal,
-      onlyProd,
+      onlyLocal: Array.from(localIds).filter(id => !prodIds.has(id)),
+      onlyProd: Array.from(prodIds).filter(id => !localIds.has(id)),
     });
   }
   return diffs;
 }
 
 function buildUpsertSql(table: TableConfig, columns: string[]): string {
-  const quotedCols = columns.map(quoteIdent);
-  const colList = quotedCols.join(', ');
+  const colList = columns.map(quoteIdent).join(', ');
   const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
   const conflictCol = quoteIdent(table.conflictKey);
 
-  if (table.timestampCol === null) {
+  if (table.strategy.kind === 'insert-only') {
     return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
             ON CONFLICT (${conflictCol}) DO NOTHING`;
   }
 
+  const ts = table.strategy.timestampCol;
   const updateSet = columns
     .filter(c => c !== table.conflictKey)
     .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
@@ -108,43 +168,47 @@ function buildUpsertSql(table: TableConfig, columns: string[]): string {
 
   return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
           ON CONFLICT (${conflictCol}) DO UPDATE SET ${updateSet}
-          WHERE EXCLUDED.${table.timestampCol} > ${table.name}.${table.timestampCol}`;
+          WHERE EXCLUDED.${ts} > ${table.name}.${ts}`;
 }
 
 export interface SyncResult {
   table: string;
   rows: number;
-  direction: string;
+  failed: number;
+  direction: SyncDirection;
 }
 
 export async function syncDirection(
   source: Client,
   target: Client,
   table: TableConfig,
-  direction: string
+  direction: SyncDirection
 ): Promise<SyncResult> {
+  const tableName = stripQuotes(table.name);
   const columns = await getColumns(source, table.name);
-  if (columns.length === 0) return { table: stripQuotes(table.name), rows: 0, direction };
+  if (columns.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
 
   const sourceRows = await source.query(
     `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`
   );
-  if (sourceRows.rows.length === 0) return { table: stripQuotes(table.name), rows: 0, direction };
+  if (sourceRows.rows.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
 
   const sql = buildUpsertSql(table, columns);
 
   let synced = 0;
+  let failed = 0;
   for (const row of sourceRows.rows) {
     const values = columns.map(c => row[c]);
     try {
       await target.query(sql, values);
       synced++;
     } catch (err) {
+      failed++;
       console.error(`  [ERR] ${table.name}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  return { table: stripQuotes(table.name), rows: synced, direction };
+  return { table: tableName, rows: synced, failed, direction };
 }
 
 export async function withClients<T>(
@@ -176,6 +240,23 @@ export async function push(prod: Client, local: Client): Promise<SyncResult[]> {
   const results: SyncResult[] = [];
   for (const table of TABLES) {
     results.push(await syncDirection(local, prod, table, 'local -> prod'));
+  }
+  return results;
+}
+
+export async function pushMissing(
+  prod: Client,
+  local: Client,
+  diffs: DiffResult[]
+): Promise<SyncResult[]> {
+  const tablesWithLocalOnly = new Set(
+    diffs.filter(d => d.onlyLocal.length > 0).map(d => d.table)
+  );
+  const results: SyncResult[] = [];
+  for (const table of TABLES) {
+    if (tablesWithLocalOnly.has(stripQuotes(table.name))) {
+      results.push(await syncDirection(local, prod, table, 'local -> prod'));
+    }
   }
   return results;
 }

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -1,0 +1,187 @@
+import { Client } from 'pg';
+
+export interface TableConfig {
+  name: string;
+  conflictKey: string;
+  orderBy: string;
+  identityCol: string;
+  timestampCol: string | null;
+}
+
+export const TABLES: TableConfig[] = [
+  { name: '"Book"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"', timestampCol: '"updatedAt"' },
+  { name: '"BookImage"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"', timestampCol: null },
+  { name: '"ProcessingHistory"', conflictKey: 'id', orderBy: '"processedAt"', identityCol: 'id', timestampCol: null },
+  { name: 'bookmarks', conflictKey: 'id', orderBy: 'updated_at', identityCol: 'file_name', timestampCol: 'updated_at' },
+  { name: '"UserBookmark"', conflictKey: 'id', orderBy: '"updatedAt"', identityCol: 'id', timestampCol: '"updatedAt"' },
+  { name: 'vocabulary_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'word', timestampCol: 'updated_at' },
+  { name: 'text_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'file_name', timestampCol: null },
+];
+
+export function stripQuotes(name: string): string {
+  return name.replace(/^"|"$/g, '');
+}
+
+function quoteIdent(name: string): string {
+  return `"${name}"`;
+}
+
+async function getColumns(client: Client, tableName: string): Promise<string[]> {
+  const bare = stripQuotes(tableName);
+  const result = await client.query(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_name = $1 AND table_schema = 'public'
+     ORDER BY ordinal_position`,
+    [bare]
+  );
+  return result.rows.map((r: { column_name: string }) => r.column_name);
+}
+
+async function getCount(client: Client, table: string): Promise<number> {
+  const bare = stripQuotes(table);
+  try {
+    const result = await client.query(`SELECT COUNT(*) as count FROM "${bare}"`);
+    return parseInt(result.rows[0].count, 10);
+  } catch {
+    return -1;
+  }
+}
+
+async function getIdentities(client: Client, table: TableConfig): Promise<Set<string>> {
+  const bare = stripQuotes(table.name);
+  try {
+    const query = (bare === 'text_entries' || bare === 'bookmarks')
+      ? `SELECT file_name || '|' || directory as key FROM "${bare}"`
+      : `SELECT ${table.identityCol}::text as key FROM "${bare}"`;
+    const result = await client.query(query);
+    return new Set(result.rows.map((r: { key: string }) => r.key));
+  } catch {
+    return new Set();
+  }
+}
+
+export interface DiffResult {
+  table: string;
+  localCount: number;
+  prodCount: number;
+  onlyLocal: string[];
+  onlyProd: string[];
+}
+
+export async function computeDiffs(prod: Client, local: Client): Promise<DiffResult[]> {
+  const diffs: DiffResult[] = [];
+  for (const table of TABLES) {
+    const [localCount, prodCount, localIds, prodIds] = await Promise.all([
+      getCount(local, table.name),
+      getCount(prod, table.name),
+      getIdentities(local, table),
+      getIdentities(prod, table),
+    ]);
+    const onlyLocal = Array.from(localIds).filter(id => !prodIds.has(id));
+    const onlyProd = Array.from(prodIds).filter(id => !localIds.has(id));
+    diffs.push({
+      table: stripQuotes(table.name),
+      localCount,
+      prodCount,
+      onlyLocal,
+      onlyProd,
+    });
+  }
+  return diffs;
+}
+
+function buildUpsertSql(table: TableConfig, columns: string[]): string {
+  const quotedCols = columns.map(quoteIdent);
+  const colList = quotedCols.join(', ');
+  const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
+  const conflictCol = quoteIdent(table.conflictKey);
+
+  if (table.timestampCol === null) {
+    return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
+            ON CONFLICT (${conflictCol}) DO NOTHING`;
+  }
+
+  const updateSet = columns
+    .filter(c => c !== table.conflictKey)
+    .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
+    .join(', ');
+
+  return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
+          ON CONFLICT (${conflictCol}) DO UPDATE SET ${updateSet}
+          WHERE EXCLUDED.${table.timestampCol} > ${table.name}.${table.timestampCol}`;
+}
+
+export interface SyncResult {
+  table: string;
+  rows: number;
+  direction: string;
+}
+
+export async function syncDirection(
+  source: Client,
+  target: Client,
+  table: TableConfig,
+  direction: string
+): Promise<SyncResult> {
+  const columns = await getColumns(source, table.name);
+  if (columns.length === 0) return { table: stripQuotes(table.name), rows: 0, direction };
+
+  const sourceRows = await source.query(
+    `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`
+  );
+  if (sourceRows.rows.length === 0) return { table: stripQuotes(table.name), rows: 0, direction };
+
+  const sql = buildUpsertSql(table, columns);
+
+  let synced = 0;
+  for (const row of sourceRows.rows) {
+    const values = columns.map(c => row[c]);
+    try {
+      await target.query(sql, values);
+      synced++;
+    } catch (err) {
+      console.error(`  [ERR] ${table.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { table: stripQuotes(table.name), rows: synced, direction };
+}
+
+export async function withClients<T>(
+  prodUrl: string,
+  localUrl: string,
+  fn: (prod: Client, local: Client) => Promise<T>
+): Promise<T> {
+  const prod = new Client({ connectionString: prodUrl, ssl: { rejectUnauthorized: false } });
+  const local = new Client({ connectionString: localUrl });
+
+  try {
+    await Promise.all([prod.connect(), local.connect()]);
+    return await fn(prod, local);
+  } finally {
+    await prod.end().catch(() => {});
+    await local.end().catch(() => {});
+  }
+}
+
+export async function pull(prod: Client, local: Client): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const table of TABLES) {
+    results.push(await syncDirection(prod, local, table, 'prod -> local'));
+  }
+  return results;
+}
+
+export async function push(prod: Client, local: Client): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const table of TABLES) {
+    results.push(await syncDirection(local, prod, table, 'local -> prod'));
+  }
+  return results;
+}
+
+export async function fullSync(prod: Client, local: Client): Promise<SyncResult[]> {
+  const pullResults = await pull(prod, local);
+  const pushResults = await push(prod, local);
+  return [...pullResults, ...pushResults];
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3333",
-    "dev-lan": "next dev --hostname 192.168.1.15 --port 3001",
+    "dev": "tsx scripts/dev-with-sync.ts",
+    "dev-lan": "tsx scripts/dev-with-sync.ts --lan",
+    "dev:nosync": "next dev --port 3333",
+    "dev-lan:nosync": "next dev --hostname 192.168.1.15 --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/db/sync.ts
+++ b/scripts/db/sync.ts
@@ -10,6 +10,14 @@
 import pg from 'pg';
 import readline from 'readline';
 import dotenv from 'dotenv';
+import {
+  TABLES,
+  computeDiffs,
+  syncDirection,
+  stripQuotes,
+  type DiffResult,
+} from '../../lib/db/sync-core';
+
 dotenv.config({ path: '.env.local' });
 
 const PROD_URL = process.env.PROD_DATABASE_URL;
@@ -20,35 +28,10 @@ if (!PROD_URL || !LOCAL_URL) {
   process.exit(1);
 }
 
-interface TableConfig {
-  name: string;
-  conflictKey: string;
-  orderBy: string;
-  identityCol: string;
-}
-
-const TABLES: TableConfig[] = [
-  { name: '"Book"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"' },
-  { name: '"BookImage"', conflictKey: 'id', orderBy: '"createdAt"', identityCol: '"fileName"' },
-  { name: '"ProcessingHistory"', conflictKey: 'id', orderBy: '"processedAt"', identityCol: 'id' },
-  { name: 'bookmarks', conflictKey: 'id', orderBy: 'updated_at', identityCol: 'file_name' },
-  { name: '"UserBookmark"', conflictKey: 'id', orderBy: '"updatedAt"', identityCol: 'id' },
-  { name: 'vocabulary_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'word' },
-  { name: 'text_entries', conflictKey: 'id', orderBy: 'created_at', identityCol: 'file_name' },
-];
-
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
 function ask(question: string): Promise<string> {
   return new Promise(resolve => rl.question(question, resolve));
-}
-
-function stripQuotes(name: string): string {
-  return name.replace(/^"|"$/g, '');
-}
-
-function quoteIdent(name: string): string {
-  return `"${name}"`;
 }
 
 function pad(str: string, len: number): string {
@@ -57,79 +40,6 @@ function pad(str: string, len: number): string {
 
 function padLeft(str: string, len: number): string {
   return str.length >= len ? str : ' '.repeat(len - str.length) + str;
-}
-
-async function getColumns(client: pg.Client, tableName: string): Promise<string[]> {
-  const bare = stripQuotes(tableName);
-  const result = await client.query(
-    `SELECT column_name FROM information_schema.columns
-     WHERE table_name = $1 AND table_schema = 'public'
-     ORDER BY ordinal_position`,
-    [bare]
-  );
-  return result.rows.map((r: { column_name: string }) => r.column_name);
-}
-
-async function getCount(client: pg.Client, table: string): Promise<number> {
-  const bare = stripQuotes(table);
-  try {
-    const result = await client.query(
-      `SELECT COUNT(*) as count FROM "${bare}"`
-    );
-    return parseInt(result.rows[0].count, 10);
-  } catch {
-    return -1;
-  }
-}
-
-async function getIdentities(client: pg.Client, table: TableConfig): Promise<Set<string>> {
-  const bare = stripQuotes(table.name);
-  try {
-    let query: string;
-    if (bare === 'text_entries' || bare === 'bookmarks') {
-      query = `SELECT file_name || '|' || directory as key FROM "${bare}"`;
-    } else {
-      query = `SELECT ${table.identityCol}::text as key FROM "${bare}"`;
-    }
-    const result = await client.query(query);
-    return new Set(result.rows.map((r: { key: string }) => r.key));
-  } catch {
-    return new Set();
-  }
-}
-
-interface DiffResult {
-  table: string;
-  localCount: number;
-  prodCount: number;
-  onlyLocal: string[];
-  onlyProd: string[];
-}
-
-async function computeDiffs(prod: pg.Client, local: pg.Client): Promise<DiffResult[]> {
-  const diffs: DiffResult[] = [];
-
-  for (const table of TABLES) {
-    const [localCount, prodCount, localIds, prodIds] = await Promise.all([
-      getCount(local, table.name),
-      getCount(prod, table.name),
-      getIdentities(local, table),
-      getIdentities(prod, table),
-    ]);
-
-    const onlyLocal = [...localIds].filter(id => !prodIds.has(id));
-    const onlyProd = [...prodIds].filter(id => !localIds.has(id));
-
-    diffs.push({
-      table: stripQuotes(table.name),
-      localCount,
-      prodCount,
-      onlyLocal,
-      onlyProd,
-    });
-  }
-
-  return diffs;
 }
 
 function printDashboard(diffs: DiffResult[]) {
@@ -158,54 +68,11 @@ function printDashboard(diffs: DiffResult[]) {
   console.log();
 }
 
-async function syncDirection(
-  source: pg.Client,
-  target: pg.Client,
-  table: TableConfig,
-  direction: string
-): Promise<number> {
-  const columns = await getColumns(source, table.name);
-  if (columns.length === 0) return 0;
-
-  const sourceRows = await source.query(
-    `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`
-  );
-
-  if (sourceRows.rows.length === 0) return 0;
-
-  const quotedCols = columns.map(quoteIdent);
-  const colList = quotedCols.join(', ');
-  const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
-  const conflictCol = quoteIdent(table.conflictKey);
-  const updateSet = columns
-    .filter(c => c !== table.conflictKey)
-    .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
-    .join(', ');
-
-  let synced = 0;
-  for (const row of sourceRows.rows) {
-    const values = columns.map(c => row[c]);
-    try {
-      await target.query(
-        `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
-         ON CONFLICT (${conflictCol}) DO UPDATE SET ${updateSet}`,
-        values
-      );
-      synced++;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`  [ERR] ${table.name}: ${msg}`);
-    }
-  }
-
-  console.log(`  ${stripQuotes(table.name)}: ${synced} rows ${direction}`);
-  return synced;
-}
-
 async function pullFromProd(prod: pg.Client, local: pg.Client) {
   console.log('\nPulling prod -> local...');
   for (const table of TABLES) {
-    await syncDirection(prod, local, table, '<- prod');
+    const result = await syncDirection(prod, local, table, '<- prod');
+    console.log(`  ${result.table}: ${result.rows} rows <- prod`);
   }
   console.log('Done.\n');
 }
@@ -238,7 +105,8 @@ async function pushToProd(prod: pg.Client, local: pg.Client, diffs: DiffResult[]
   for (const table of TABLES) {
     const diff = missing.find(d => d.table === stripQuotes(table.name));
     if (diff) {
-      await syncDirection(local, prod, table, '-> prod');
+      const result = await syncDirection(local, prod, table, '-> prod');
+      console.log(`  ${result.table}: ${result.rows} rows -> prod`);
     }
   }
   console.log('Done.\n');
@@ -266,7 +134,7 @@ async function showDiff(diffs: DiffResult[]) {
   }
 }
 
-async function fullSync(prod: pg.Client, local: pg.Client, diffs: DiffResult[]) {
+async function fullSyncInteractive(prod: pg.Client, local: pg.Client, diffs: DiffResult[]) {
   const hasMissingInProd = diffs.some(d => d.onlyLocal.length > 0);
   const hasMissingInLocal = diffs.some(d => d.onlyProd.length > 0);
 
@@ -288,7 +156,8 @@ async function fullSync(prod: pg.Client, local: pg.Client, diffs: DiffResult[]) 
   if (hasMissingInLocal) {
     console.log('\nPulling prod -> local...');
     for (const table of TABLES) {
-      await syncDirection(prod, local, table, '<- prod');
+      const result = await syncDirection(prod, local, table, '<- prod');
+      console.log(`  ${result.table}: ${result.rows} rows <- prod`);
     }
   }
 
@@ -297,7 +166,8 @@ async function fullSync(prod: pg.Client, local: pg.Client, diffs: DiffResult[]) 
     for (const table of TABLES) {
       const diff = diffs.find(d => d.table === stripQuotes(table.name));
       if (diff && diff.onlyLocal.length > 0) {
-        await syncDirection(local, prod, table, '-> prod');
+        const result = await syncDirection(local, prod, table, '-> prod');
+        console.log(`  ${result.table}: ${result.rows} rows -> prod`);
       }
     }
   }
@@ -345,7 +215,7 @@ async function main() {
           await showDiff(diffs);
           break;
         case '4':
-          await fullSync(prod, local, diffs);
+          await fullSyncInteractive(prod, local, diffs);
           diffs = await computeDiffs(prod, local);
           printDashboard(diffs);
           break;

--- a/scripts/db/sync.ts
+++ b/scripts/db/sync.ts
@@ -14,8 +14,9 @@ import {
   TABLES,
   computeDiffs,
   syncDirection,
-  stripQuotes,
+  pushMissing,
   type DiffResult,
+  type SyncResult,
 } from '../../lib/db/sync-core';
 
 dotenv.config({ path: '.env.local' });
@@ -42,13 +43,22 @@ function padLeft(str: string, len: number): string {
   return str.length >= len ? str : ' '.repeat(len - str.length) + str;
 }
 
+function renderCount(n: number | null): string {
+  return n === null ? '?' : String(n);
+}
+
+function logSyncResult(r: SyncResult) {
+  const failedSuffix = r.failed > 0 ? `, ${r.failed} failed` : '';
+  console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${failedSuffix}`);
+}
+
 function printDashboard(diffs: DiffResult[]) {
   console.log('\n  ' + pad('Table', 22) + padLeft('Local', 7) + padLeft('Prod', 7) + '   Status');
   console.log('  ' + '-'.repeat(60));
 
   for (const d of diffs) {
-    const localStr = d.localCount === -1 ? 'N/A' : String(d.localCount);
-    const prodStr = d.prodCount === -1 ? 'N/A' : String(d.prodCount);
+    const localStr = renderCount(d.localCount);
+    const prodStr = renderCount(d.prodCount);
     let status = 'in sync';
 
     if (d.onlyLocal.length > 0 && d.onlyProd.length > 0) {
@@ -57,11 +67,15 @@ function printDashboard(diffs: DiffResult[]) {
       status = `+${d.onlyLocal.length} local only`;
     } else if (d.onlyProd.length > 0) {
       status = `+${d.onlyProd.length} prod only`;
+    } else if (d.localCount === null || d.prodCount === null) {
+      status = 'count unavailable';
     } else if (d.localCount !== d.prodCount) {
       status = 'counts differ (same keys)';
     }
 
-    const ok = d.onlyLocal.length === 0 && d.onlyProd.length === 0 && d.localCount === d.prodCount;
+    const ok = d.onlyLocal.length === 0 && d.onlyProd.length === 0
+      && d.localCount !== null && d.prodCount !== null
+      && d.localCount === d.prodCount;
     const marker = ok ? ' ' : '*';
     console.log(`${marker} ${pad(d.table, 22)}${padLeft(localStr, 7)}${padLeft(prodStr, 7)}   ${status}`);
   }
@@ -71,8 +85,8 @@ function printDashboard(diffs: DiffResult[]) {
 async function pullFromProd(prod: pg.Client, local: pg.Client) {
   console.log('\nPulling prod -> local...');
   for (const table of TABLES) {
-    const result = await syncDirection(prod, local, table, '<- prod');
-    console.log(`  ${result.table}: ${result.rows} rows <- prod`);
+    const result = await syncDirection(prod, local, table, 'prod -> local');
+    logSyncResult(result);
   }
   console.log('Done.\n');
 }
@@ -102,13 +116,8 @@ async function pushToProd(prod: pg.Client, local: pg.Client, diffs: DiffResult[]
   }
 
   console.log('\nPushing local -> prod...');
-  for (const table of TABLES) {
-    const diff = missing.find(d => d.table === stripQuotes(table.name));
-    if (diff) {
-      const result = await syncDirection(local, prod, table, '-> prod');
-      console.log(`  ${result.table}: ${result.rows} rows -> prod`);
-    }
-  }
+  const results = await pushMissing(prod, local, diffs);
+  for (const r of results) logSyncResult(r);
   console.log('Done.\n');
 }
 
@@ -156,20 +165,15 @@ async function fullSyncInteractive(prod: pg.Client, local: pg.Client, diffs: Dif
   if (hasMissingInLocal) {
     console.log('\nPulling prod -> local...');
     for (const table of TABLES) {
-      const result = await syncDirection(prod, local, table, '<- prod');
-      console.log(`  ${result.table}: ${result.rows} rows <- prod`);
+      const result = await syncDirection(prod, local, table, 'prod -> local');
+      logSyncResult(result);
     }
   }
 
   if (hasMissingInProd) {
     console.log('\nPushing local -> prod...');
-    for (const table of TABLES) {
-      const diff = diffs.find(d => d.table === stripQuotes(table.name));
-      if (diff && diff.onlyLocal.length > 0) {
-        const result = await syncDirection(local, prod, table, '-> prod');
-        console.log(`  ${result.table}: ${result.rows} rows -> prod`);
-      }
-    }
+    const results = await pushMissing(prod, local, diffs);
+    for (const r of results) logSyncResult(r);
   }
 
   console.log('Done.\n');

--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -11,42 +11,33 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
-import dotenv from 'dotenv';
+import { resolve } from 'node:path';
 import { Client } from 'pg';
-import { fullSync, withClients, type SyncResult } from '../lib/db/sync-core';
+import dotenv from 'dotenv';
+import { fullSync, type SyncResult } from '../lib/db/sync-core';
 
 dotenv.config({ path: '.env.local' });
 
 const SYNC_TIMEOUT_MS = 10_000;
+const SHUTDOWN_GRACE_MS = 5_000;
 
 function nextDevArgs(): string[] {
   const lan = process.argv.includes('--lan');
   return lan
-    ? ['next', 'dev', '--hostname', '192.168.1.15', '--port', '3001']
-    : ['next', 'dev', '--port', '3333'];
+    ? ['dev', '--hostname', '192.168.1.15', '--port', '3001']
+    : ['dev', '--port', '3333'];
 }
 
 function summarize(label: string, results: SyncResult[]) {
-  const meaningful = results.filter(r => r.rows > 0);
+  const meaningful = results.filter(r => r.rows > 0 || r.failed > 0);
   if (meaningful.length === 0) {
     console.log(`[sync] ${label}: nothing to transfer`);
     return;
   }
   console.log(`[sync] ${label}:`);
   for (const r of meaningful) {
-    console.log(`  ${r.table}: ${r.rows} rows ${r.direction}`);
-  }
-}
-
-async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-  });
-  try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    if (timer) clearTimeout(timer);
+    const failedSuffix = r.failed > 0 ? `, ${r.failed} failed` : '';
+    console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${failedSuffix}`);
   }
 }
 
@@ -60,26 +51,45 @@ async function runSync(label: string): Promise<void> {
   }
 
   console.log(`[sync] ${label}: running full sync...`);
+  const prod = new Client({ connectionString: prodUrl, ssl: { rejectUnauthorized: false } });
+  const local = new Client({ connectionString: localUrl });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    prod.end().catch(() => {});
+    local.end().catch(() => {});
+  }, SYNC_TIMEOUT_MS);
+
   try {
-    const results = await withTimeout(
-      withClients(prodUrl, localUrl, (prod: Client, local: Client) => fullSync(prod, local)),
-      SYNC_TIMEOUT_MS,
-      `${label} sync`
-    );
+    await Promise.all([prod.connect(), local.connect()]);
+    const results = await fullSync(prod, local);
     summarize(label, results);
   } catch (err) {
-    console.warn(`[sync] ${label} failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (timedOut) {
+      console.warn(`[sync] ${label} timed out after ${SYNC_TIMEOUT_MS}ms`);
+    } else {
+      console.warn(`[sync] ${label} failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
     console.warn('[sync] continuing without sync');
+  } finally {
+    clearTimeout(timer);
+    if (!timedOut) {
+      await prod.end().catch(() => {});
+      await local.end().catch(() => {});
+    }
   }
 }
 
 function spawnNextDev(): ChildProcess {
-  const [cmd, ...args] = nextDevArgs();
-  const child = spawn(cmd, args, {
+  // Spawn node with next's bin path directly so the child is a real Node
+  // process (not cmd.exe on Windows). The terminal's Ctrl+C is broadcast to
+  // every process attached to the console group, so next dev gets the signal
+  // naturally and shuts down gracefully without us calling child.kill.
+  const nextBin = resolve(process.cwd(), 'node_modules/next/dist/bin/next');
+  return spawn(process.execPath, [nextBin, ...nextDevArgs()], {
     stdio: 'inherit',
-    shell: process.platform === 'win32',
   });
-  return child;
 }
 
 async function main() {
@@ -94,11 +104,15 @@ async function main() {
       process.exit(130);
     }
     shuttingDown = true;
-    console.log('\n[sync] Ctrl+C received, stopping next dev and pushing to prod...');
+    console.log('\n[sync] Ctrl+C received, waiting for next dev to exit then running shutdown sync...');
     console.log('[sync] press Ctrl+C again to skip shutdown sync');
-    if (!child.killed) {
-      child.kill('SIGINT');
-    }
+
+    setTimeout(() => {
+      if (child.exitCode === null && !child.killed) {
+        console.log(`[sync] next dev did not exit within ${SHUTDOWN_GRACE_MS}ms, forcing kill`);
+        child.kill('SIGKILL');
+      }
+    }, SHUTDOWN_GRACE_MS).unref();
   };
   process.on('SIGINT', handleSigint);
 

--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env npx tsx
+/**
+ * Dev wrapper that syncs the local DB with prod on startup and on Ctrl+C.
+ *
+ * Usage:
+ *   npx tsx scripts/dev-with-sync.ts            # next dev on default port
+ *   npx tsx scripts/dev-with-sync.ts --lan      # next dev on LAN host/port
+ *
+ * Skip the sync entirely with `npm run dev:nosync`.
+ * Press Ctrl+C twice to skip the shutdown sync if it hangs.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import dotenv from 'dotenv';
+import { Client } from 'pg';
+import { fullSync, withClients, type SyncResult } from '../lib/db/sync-core';
+
+dotenv.config({ path: '.env.local' });
+
+const SYNC_TIMEOUT_MS = 10_000;
+
+function nextDevArgs(): string[] {
+  const lan = process.argv.includes('--lan');
+  return lan
+    ? ['next', 'dev', '--hostname', '192.168.1.15', '--port', '3001']
+    : ['next', 'dev', '--port', '3333'];
+}
+
+function summarize(label: string, results: SyncResult[]) {
+  const meaningful = results.filter(r => r.rows > 0);
+  if (meaningful.length === 0) {
+    console.log(`[sync] ${label}: nothing to transfer`);
+    return;
+  }
+  console.log(`[sync] ${label}:`);
+  for (const r of meaningful) {
+    console.log(`  ${r.table}: ${r.rows} rows ${r.direction}`);
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function runSync(label: string): Promise<void> {
+  const prodUrl = process.env.PROD_DATABASE_URL;
+  const localUrl = process.env.DATABASE_URL;
+
+  if (!prodUrl || !localUrl) {
+    console.log(`[sync] ${label}: skipped (PROD_DATABASE_URL or DATABASE_URL not set)`);
+    return;
+  }
+
+  console.log(`[sync] ${label}: running full sync...`);
+  try {
+    const results = await withTimeout(
+      withClients(prodUrl, localUrl, (prod: Client, local: Client) => fullSync(prod, local)),
+      SYNC_TIMEOUT_MS,
+      `${label} sync`
+    );
+    summarize(label, results);
+  } catch (err) {
+    console.warn(`[sync] ${label} failed: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn('[sync] continuing without sync');
+  }
+}
+
+function spawnNextDev(): ChildProcess {
+  const [cmd, ...args] = nextDevArgs();
+  const child = spawn(cmd, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  return child;
+}
+
+async function main() {
+  await runSync('startup');
+
+  const child = spawnNextDev();
+
+  let shuttingDown = false;
+  const handleSigint = () => {
+    if (shuttingDown) {
+      console.log('\n[sync] second Ctrl+C received, exiting immediately');
+      process.exit(130);
+    }
+    shuttingDown = true;
+    console.log('\n[sync] Ctrl+C received, stopping next dev and pushing to prod...');
+    console.log('[sync] press Ctrl+C again to skip shutdown sync');
+    if (!child.killed) {
+      child.kill('SIGINT');
+    }
+  };
+  process.on('SIGINT', handleSigint);
+
+  child.on('exit', async (code) => {
+    process.off('SIGINT', handleSigint);
+    if (shuttingDown) {
+      await runSync('shutdown');
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+main().catch(err => {
+  console.error('[dev-with-sync] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a wrapper script (`scripts/dev-with-sync.ts`) that runs a full prod/local DB sync on `npm run dev` startup and again on Ctrl+C, with a 10s timeout per direction and warn-and-continue on failure.
- Extracts the existing sync logic (previously duplicated between `scripts/db/sync.ts` and `app/api/db-sync/route.ts`) into a single `lib/db/sync-core.ts` module so the interactive tool, the API route, and the new wrapper all share it.
- Adds **timestamp-aware upserts** so concurrent PCs can't clobber each other: rows on tables with `updated_at`/`updatedAt` (`Book`, `bookmarks`, `UserBookmark`, `vocabulary_entries`) only update when the source row is newer; immutable tables (`BookImage`, `ProcessingHistory`, `text_entries`) use `DO NOTHING` on conflict.
- `dev` and `dev-lan` now go through the wrapper. `dev:nosync` and `dev-lan:nosync` keep the raw `next dev` as escape hatches. Press Ctrl+C twice to skip the shutdown sync.

## Why
Previously bookmarks and books written on PC1's local DB never reached prod (or PC2) until the manual `npm run db:sync` button was hit. With this change, every dev session begins by pulling the latest from prod and ends by pushing local changes back, so prod is always the merge point between PC1, PC2, and the phone.

## Test plan
- [ ] `npm run dev` on PC1: see `[sync] startup: ...` log, dev server boots normally, Ctrl+C triggers `[sync] shutdown: ...` then exits.
- [ ] `npm run dev:nosync` skips the sync entirely.
- [ ] With `PROD_DATABASE_URL` unset, the wrapper logs the skip and still boots `next dev`.
- [ ] With prod unreachable (e.g. bogus URL), the wrapper warns after the 10s timeout and still boots `next dev`.
- [ ] Existing `npm run db:sync` interactive tool still works.
- [ ] Existing `/api/db-sync` route still returns diff/sync responses.
- [ ] Make a bookmark on PC1, Ctrl+C to push, run `npm run dev` on PC2, confirm the bookmark appears.