### PR TITLE
fix: bump default sync timeout to 60s

### DIFF
--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -18,7 +18,12 @@ import { fullSync, type SyncResult } from '../lib/db/sync-core';
 
 dotenv.config({ path: '.env.local' });
 
-const SYNC_TIMEOUT_MS = Number(process.env.SYNC_TIMEOUT_MS) || 60_000;
+function parseTimeoutMs(raw: string | undefined, defaultMs: number): number {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultMs;
+}
+
+const SYNC_TIMEOUT_MS = parseTimeoutMs(process.env.SYNC_TIMEOUT_MS, 60_000);
 const SHUTDOWN_GRACE_MS = 5_000;
 
 function nextDevArgs(): string[] {

--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -18,7 +18,7 @@ import { fullSync, type SyncResult } from '../lib/db/sync-core';
 
 dotenv.config({ path: '.env.local' });
 
-const SYNC_TIMEOUT_MS = 10_000;
+const SYNC_TIMEOUT_MS = Number(process.env.SYNC_TIMEOUT_MS) || 60_000;
 const SHUTDOWN_GRACE_MS = 5_000;
 
 function nextDevArgs(): string[] {

--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -25,6 +25,7 @@ function parseTimeoutMs(raw: string | undefined, defaultMs: number): number {
 
 const SYNC_TIMEOUT_MS = parseTimeoutMs(process.env.SYNC_TIMEOUT_MS, 60_000);
 const SHUTDOWN_GRACE_MS = 5_000;
+const CONNECT_TIMEOUT_MS = 5_000;
 
 function nextDevArgs(): string[] {
   const lan = process.argv.includes('--lan');
@@ -56,8 +57,15 @@ async function runSync(label: string): Promise<void> {
   }
 
   console.log(`[sync] ${label}: running full sync...`);
-  const prod = new Client({ connectionString: prodUrl, ssl: { rejectUnauthorized: false } });
-  const local = new Client({ connectionString: localUrl });
+  const prod = new Client({
+    connectionString: prodUrl,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+  });
+  const local = new Client({
+    connectionString: localUrl,
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+  });
 
   let timedOut = false;
   const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Bumps `SYNC_TIMEOUT_MS` default from 10s to 60s. 10s wasn't enough for Neon cold-start + serial INSERT of accumulated text_entries rows, causing the startup pull to time out and the dev wrapper to skip sync entirely.
- Adds `SYNC_TIMEOUT_MS` env var override for cases where 60s is still tight (or where you want to clamp it shorter for fast iteration).

## Why
Reported on PC2 today: `[sync] startup: running full sync...` followed immediately by `startup timed out after 10000ms`. Books added on PC1 never reached PC2's local DB. The 60s default gives Neon time to cold-start and the serial inserts time to complete; the timeout is still bounded so a hung connection can't strand dev startup.

## Test plan
- [ ] `npm run dev` on PC2 with a recently-added book on prod completes the startup pull within 60s and the new book appears in the library.
- [ ] `SYNC_TIMEOUT_MS=5000 npm run dev` (or set in `.env.local`) shortens the timeout and a slow Neon will fail in ~5s as expected.
- [ ] Without the env var set, the default 60s applies.