### PR TITLE
fix: conflict on natural unique keys (not auto-incremented id)

### DIFF
--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -4,11 +4,13 @@ export type SyncDirection = 'prod -> local' | 'local -> prod';
 
 type IdentityKey =
   | { kind: 'column'; col: string }
-  | { kind: 'composite'; cols: [string, string]; sep: string };
+  | { kind: 'composite'; cols: readonly [string, string]; sep: string };
 
 type ConflictKey =
   | { kind: 'column'; col: string }
-  | { kind: 'composite'; cols: string[] };
+  | { kind: 'composite'; cols: readonly [string, string, ...string[]] };
+
+const FILE_DIR_PAIR = ['file_name', 'directory'] as const;
 
 type ConflictStrategy =
   | { kind: 'insert-only' }
@@ -52,13 +54,17 @@ export const TABLES: TableConfig[] = [
   },
   {
     name: 'bookmarks',
-    conflictKey: { kind: 'composite', cols: ['file_name', 'directory'] },
+    conflictKey: { kind: 'composite', cols: FILE_DIR_PAIR },
     orderBy: 'updated_at',
-    identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
+    identity: { kind: 'composite', cols: FILE_DIR_PAIR, sep: '|' },
     strategy: { kind: 'last-write-wins', timestampCol: 'updated_at' },
   },
   {
     name: '"UserBookmark"',
+    // userId is technically nullable; Postgres treats NULLs as distinct in
+    // unique indexes, so legacy NULL rows would multiply on every sync. The
+    // Prisma schema sets a default of "default", so any row inserted via the
+    // app is safe — but backfill before sync if NULLs ever appear.
     conflictKey: { kind: 'composite', cols: ['bookId', 'userId'] },
     orderBy: '"updatedAt"',
     identity: { kind: 'column', col: 'id' },
@@ -73,9 +79,9 @@ export const TABLES: TableConfig[] = [
   },
   {
     name: 'text_entries',
-    conflictKey: { kind: 'composite', cols: ['file_name', 'directory'] },
+    conflictKey: { kind: 'composite', cols: FILE_DIR_PAIR },
     orderBy: 'created_at',
-    identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
+    identity: { kind: 'composite', cols: FILE_DIR_PAIR, sep: '|' },
     strategy: { kind: 'insert-only' },
   },
 ];
@@ -160,7 +166,7 @@ export async function computeDiffs(prod: Client, local: Client): Promise<DiffRes
   return diffs;
 }
 
-function conflictColumns(key: ConflictKey): string[] {
+function conflictColumns(key: ConflictKey): readonly string[] {
   return key.kind === 'column' ? [key.col] : key.cols;
 }
 

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -12,6 +12,10 @@ type ConflictKey =
 
 const FILE_DIR_PAIR = ['file_name', 'directory'] as const;
 
+// Every table in this schema names its surrogate primary key `id`. If that
+// assumption ever changes, lift this into a per-table TableConfig field.
+const SURROGATE_PK = 'id';
+
 type ConflictStrategy =
   | { kind: 'insert-only' }
   | { kind: 'last-write-wins'; timestampCol: string };
@@ -183,8 +187,10 @@ function buildUpsertSql(table: TableConfig, columns: string[]): string {
   }
 
   const ts = table.strategy.timestampCol;
-  // Never overwrite the conflict columns or the primary key on update.
-  const excludedFromUpdate = new Set<string>([...conflictCols, 'id']);
+  // Preserve the target's surrogate PK on conflict so child FK references
+  // already pointing at it stay valid. The conflict columns are likewise
+  // excluded since updating them would change the row's identity.
+  const excludedFromUpdate = new Set<string>([...conflictCols, SURROGATE_PK]);
   const updateSet = columns
     .filter(c => !excludedFromUpdate.has(c))
     .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -25,7 +25,13 @@ export interface TableConfig {
 export const TABLES: TableConfig[] = [
   {
     name: '"Book"',
-    conflictKey: { kind: 'column', col: 'fileName' },
+    // Conflict on id (cuid), not fileName: BookImage, UserBookmark, and
+    // ProcessingHistory FK to Book.id. Resolving conflicts on fileName would
+    // keep the target's id while incoming child rows still reference the
+    // source's id, leaving child FK references dangling. In this app's
+    // workflow books are only ingested via the EPUB pipeline on a single
+    // machine, so cuids stay consistent across DBs and id-conflict is safe.
+    conflictKey: { kind: 'column', col: 'id' },
     orderBy: '"createdAt"',
     identity: { kind: 'column', col: '"fileName"' },
     strategy: { kind: 'last-write-wins', timestampCol: '"updatedAt"' },

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -6,13 +6,17 @@ type IdentityKey =
   | { kind: 'column'; col: string }
   | { kind: 'composite'; cols: [string, string]; sep: string };
 
+type ConflictKey =
+  | { kind: 'column'; col: string }
+  | { kind: 'composite'; cols: string[] };
+
 type ConflictStrategy =
   | { kind: 'insert-only' }
   | { kind: 'last-write-wins'; timestampCol: string };
 
 export interface TableConfig {
   name: string;
-  conflictKey: string;
+  conflictKey: ConflictKey;
   orderBy: string;
   identity: IdentityKey;
   strategy: ConflictStrategy;
@@ -21,49 +25,49 @@ export interface TableConfig {
 export const TABLES: TableConfig[] = [
   {
     name: '"Book"',
-    conflictKey: 'id',
+    conflictKey: { kind: 'column', col: 'fileName' },
     orderBy: '"createdAt"',
     identity: { kind: 'column', col: '"fileName"' },
     strategy: { kind: 'last-write-wins', timestampCol: '"updatedAt"' },
   },
   {
     name: '"BookImage"',
-    conflictKey: 'id',
+    conflictKey: { kind: 'column', col: 'id' },
     orderBy: '"createdAt"',
     identity: { kind: 'column', col: '"fileName"' },
     strategy: { kind: 'insert-only' },
   },
   {
     name: '"ProcessingHistory"',
-    conflictKey: 'id',
+    conflictKey: { kind: 'column', col: 'id' },
     orderBy: '"processedAt"',
     identity: { kind: 'column', col: 'id' },
     strategy: { kind: 'insert-only' },
   },
   {
     name: 'bookmarks',
-    conflictKey: 'id',
+    conflictKey: { kind: 'composite', cols: ['file_name', 'directory'] },
     orderBy: 'updated_at',
     identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
     strategy: { kind: 'last-write-wins', timestampCol: 'updated_at' },
   },
   {
     name: '"UserBookmark"',
-    conflictKey: 'id',
+    conflictKey: { kind: 'composite', cols: ['bookId', 'userId'] },
     orderBy: '"updatedAt"',
     identity: { kind: 'column', col: 'id' },
     strategy: { kind: 'last-write-wins', timestampCol: '"updatedAt"' },
   },
   {
     name: 'vocabulary_entries',
-    conflictKey: 'id',
+    conflictKey: { kind: 'column', col: 'id' },
     orderBy: 'created_at',
     identity: { kind: 'column', col: 'word' },
     strategy: { kind: 'last-write-wins', timestampCol: 'updated_at' },
   },
   {
     name: 'text_entries',
-    conflictKey: 'id',
+    conflictKey: { kind: 'composite', cols: ['file_name', 'directory'] },
     orderBy: 'created_at',
     identity: { kind: 'composite', cols: ['file_name', 'directory'], sep: '|' },
     strategy: { kind: 'insert-only' },
@@ -150,24 +154,32 @@ export async function computeDiffs(prod: Client, local: Client): Promise<DiffRes
   return diffs;
 }
 
+function conflictColumns(key: ConflictKey): string[] {
+  return key.kind === 'column' ? [key.col] : key.cols;
+}
+
 function buildUpsertSql(table: TableConfig, columns: string[]): string {
   const colList = columns.map(quoteIdent).join(', ');
   const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
-  const conflictCol = quoteIdent(table.conflictKey);
+
+  const conflictCols = conflictColumns(table.conflictKey);
+  const conflictExpr = conflictCols.map(quoteIdent).join(', ');
 
   if (table.strategy.kind === 'insert-only') {
     return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
-            ON CONFLICT (${conflictCol}) DO NOTHING`;
+            ON CONFLICT (${conflictExpr}) DO NOTHING`;
   }
 
   const ts = table.strategy.timestampCol;
+  // Never overwrite the conflict columns or the primary key on update.
+  const excludedFromUpdate = new Set<string>([...conflictCols, 'id']);
   const updateSet = columns
-    .filter(c => c !== table.conflictKey)
+    .filter(c => !excludedFromUpdate.has(c))
     .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
     .join(', ');
 
   return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
-          ON CONFLICT (${conflictCol}) DO UPDATE SET ${updateSet}
+          ON CONFLICT (${conflictExpr}) DO UPDATE SET ${updateSet}
           WHERE EXCLUDED.${ts} > ${table.name}.${ts}`;
 }
 


### PR DESCRIPTION
## Summary
- `bookmarks`, `text_entries`, `"Book"`, `"UserBookmark"` all have a surrogate `id` plus a natural unique constraint on something else (`(file_name, directory)`, `fileName`, `(bookId, userId)`). Sync was using `ON CONFLICT (id) DO UPDATE`, which doesn't fire when local and prod hold the same logical row under different IDs — INSERT then trips the natural unique constraint and the row fails to sync.
- Refactors `TableConfig.conflictKey` from a bare `string` to a discriminated union (`{ kind: 'column' | 'composite' }`) and switches the four affected tables to conflict on their natural unique key. `BookImage`, `ProcessingHistory`, `vocabulary_entries` stay on `id` (no natural unique constraint on those).
- `buildUpsertSql` now expands composite conflict keys to `ON CONFLICT (col1, col2)` and excludes both the conflict columns and `id` from the update set, so the surrogate primary key is never overwritten on conflict.

## Why
Reported today: `[ERR] bookmarks: duplicate key value violates unique constraint "bookmarks_file_name_directory_key"` during startup pull. Local had `id=10, file='X', dir='Y'`; prod had `id=15, file='X', directory='Y'`. ID-based ON CONFLICT didn't catch it; the unique constraint did, killing the row.

Recovery for the affected machine (truncate prod's `bookmarks` + `"UserBookmark"`, then push the local copy) was run separately as a one-off — no code in this PR.

## Test plan
- [ ] `npm run dev` on the previously-broken machine completes the startup full sync without `duplicate key` errors.
- [ ] Make a bookmark on PC1, Ctrl+C to push, run `npm run dev` on PC2 (with a different local-side autoincrement state) — bookmark appears, no errors.
- [ ] `npm run db:sync` interactive tool still computes diffs correctly.
- [ ] Library page still displays books after sync.