### PR TITLE
perf: batch sync INSERTs to fix startup timeout

### DIFF
--- a/app/library/components/DbSyncModal.tsx
+++ b/app/library/components/DbSyncModal.tsx
@@ -14,6 +14,7 @@ interface DiffResult {
 interface SyncResult {
   table: string;
   rows: number;
+  skipped: number;
   failed: number;
   direction: string;
 }
@@ -199,7 +200,7 @@ export default function DbSyncModal({ onClose }: { onClose: () => void }) {
                   <p className="text-sm font-medium mb-2" style={{ color: '#34C759' }}>Sync completed</p>
                   {syncResults.map((r, i) => (
                     <p key={i} className="text-xs" style={{ color: '#1D1D1F' }}>
-                      {r.table}: {r.rows} rows ({r.direction}){r.failed > 0 ? `, ${r.failed} failed` : ''}
+                      {r.table}: {r.rows} rows ({r.direction}){r.skipped > 0 ? `, ${r.skipped} skipped` : ''}{r.failed > 0 ? `, ${r.failed} failed` : ''}
                     </p>
                   ))}
                 </div>

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -216,6 +216,19 @@ export interface SyncResult {
 
 const BATCH_SIZE = 25;
 
+function isConnectionClosed(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  return msg.includes('Client was closed')
+    || msg.includes('Connection terminated')
+    || msg.includes('Client has encountered a connection error');
+}
+
+function rowIdentityLog(table: TableConfig, row: Record<string, unknown>): string {
+  const cols = conflictColumns(table.conflictKey);
+  return cols.map(c => `${c}=${row[c]}`).join(',');
+}
+
 export async function syncDirection(
   source: Client,
   target: Client,
@@ -231,6 +244,7 @@ export async function syncDirection(
   );
   if (sourceRows.rows.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
 
+  const singleRowSql = buildBatchUpsertSql(table, columns, 1);
   let synced = 0;
   let failed = 0;
   for (let start = 0; start < sourceRows.rows.length; start += BATCH_SIZE) {
@@ -245,10 +259,33 @@ export async function syncDirection(
       await target.query(sql, values);
       synced += batch.length;
     } catch (err) {
-      failed += batch.length;
+      // A dead connection will fail every remaining batch identically — bail
+      // out so the wrapper's outer catch can report one error instead of N.
+      if (isConnectionClosed(err)) {
+        throw new Error(`[sync-core] ${tableName}: target connection closed mid-sync`);
+      }
+      // Data error: one poison row aborted the whole batch atomically. Retry
+      // row-by-row to land the valid rows and pinpoint the offender.
       console.error(
-        `  [ERR] ${table.name} (batch of ${batch.length}): ${err instanceof Error ? err.message : String(err)}`
+        `  [WARN] ${table.name} (batch of ${batch.length}) failed, retrying per-row: ` +
+        `${err instanceof Error ? err.message : String(err)}`
       );
+      for (const row of batch) {
+        const singleValues = columns.map(c => row[c]);
+        try {
+          await target.query(singleRowSql, singleValues);
+          synced++;
+        } catch (rowErr) {
+          if (isConnectionClosed(rowErr)) {
+            throw new Error(`[sync-core] ${tableName}: target connection closed mid-sync`);
+          }
+          failed++;
+          console.error(
+            `  [ERR] ${table.name} row (${rowIdentityLog(table, row)}): ` +
+            `${rowErr instanceof Error ? rowErr.message : String(rowErr)}`
+          );
+        }
+      }
     }
   }
 

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -174,15 +174,21 @@ function conflictColumns(key: ConflictKey): readonly string[] {
   return key.kind === 'column' ? [key.col] : key.cols;
 }
 
-function buildUpsertSql(table: TableConfig, columns: string[]): string {
+function buildBatchUpsertSql(table: TableConfig, columns: string[], batchSize: number): string {
   const colList = columns.map(quoteIdent).join(', ');
-  const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
+
+  const rowPlaceholders: string[] = [];
+  for (let batchI = 0; batchI < batchSize; batchI++) {
+    const cols = columns.map((_, colI) => `$${batchI * columns.length + colI + 1}`).join(', ');
+    rowPlaceholders.push(`(${cols})`);
+  }
+  const valuesClause = rowPlaceholders.join(', ');
 
   const conflictCols = conflictColumns(table.conflictKey);
   const conflictExpr = conflictCols.map(quoteIdent).join(', ');
 
   if (table.strategy.kind === 'insert-only') {
-    return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
+    return `INSERT INTO ${table.name} (${colList}) VALUES ${valuesClause}
             ON CONFLICT (${conflictExpr}) DO NOTHING`;
   }
 
@@ -196,7 +202,7 @@ function buildUpsertSql(table: TableConfig, columns: string[]): string {
     .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
     .join(', ');
 
-  return `INSERT INTO ${table.name} (${colList}) VALUES (${placeholders})
+  return `INSERT INTO ${table.name} (${colList}) VALUES ${valuesClause}
           ON CONFLICT (${conflictExpr}) DO UPDATE SET ${updateSet}
           WHERE EXCLUDED.${ts} > ${table.name}.${ts}`;
 }
@@ -207,6 +213,8 @@ export interface SyncResult {
   failed: number;
   direction: SyncDirection;
 }
+
+const BATCH_SIZE = 25;
 
 export async function syncDirection(
   source: Client,
@@ -223,18 +231,24 @@ export async function syncDirection(
   );
   if (sourceRows.rows.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
 
-  const sql = buildUpsertSql(table, columns);
-
   let synced = 0;
   let failed = 0;
-  for (const row of sourceRows.rows) {
-    const values = columns.map(c => row[c]);
+  for (let start = 0; start < sourceRows.rows.length; start += BATCH_SIZE) {
+    const batch = sourceRows.rows.slice(start, start + BATCH_SIZE);
+    const sql = buildBatchUpsertSql(table, columns, batch.length);
+    const values: unknown[] = [];
+    for (const row of batch) {
+      for (const c of columns) values.push(row[c]);
+    }
+
     try {
       await target.query(sql, values);
-      synced++;
+      synced += batch.length;
     } catch (err) {
-      failed++;
-      console.error(`  [ERR] ${table.name}: ${err instanceof Error ? err.message : String(err)}`);
+      failed += batch.length;
+      console.error(
+        `  [ERR] ${table.name} (batch of ${batch.length}): ${err instanceof Error ? err.message : String(err)}`
+      );
     }
   }
 

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -210,6 +210,7 @@ function buildBatchUpsertSql(table: TableConfig, columns: string[], batchSize: n
 export interface SyncResult {
   table: string;
   rows: number;
+  skipped: number;
   failed: number;
   direction: SyncDirection;
 }
@@ -237,15 +238,16 @@ export async function syncDirection(
 ): Promise<SyncResult> {
   const tableName = stripQuotes(table.name);
   const columns = await getColumns(source, table.name);
-  if (columns.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
+  if (columns.length === 0) return { table: tableName, rows: 0, skipped: 0, failed: 0, direction };
 
   const sourceRows = await source.query(
     `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`
   );
-  if (sourceRows.rows.length === 0) return { table: tableName, rows: 0, failed: 0, direction };
+  if (sourceRows.rows.length === 0) return { table: tableName, rows: 0, skipped: 0, failed: 0, direction };
 
   const singleRowSql = buildBatchUpsertSql(table, columns, 1);
-  let synced = 0;
+  let rows = 0;
+  let skipped = 0;
   let failed = 0;
   for (let start = 0; start < sourceRows.rows.length; start += BATCH_SIZE) {
     const batch = sourceRows.rows.slice(start, start + BATCH_SIZE);
@@ -256,8 +258,10 @@ export async function syncDirection(
     }
 
     try {
-      await target.query(sql, values);
-      synced += batch.length;
+      const result = await target.query(sql, values);
+      const affected = result.rowCount ?? 0;
+      rows += affected;
+      skipped += batch.length - affected;
     } catch (err) {
       // A dead connection will fail every remaining batch identically — bail
       // out so the wrapper's outer catch can report one error instead of N.
@@ -273,8 +277,10 @@ export async function syncDirection(
       for (const row of batch) {
         const singleValues = columns.map(c => row[c]);
         try {
-          await target.query(singleRowSql, singleValues);
-          synced++;
+          const result = await target.query(singleRowSql, singleValues);
+          const affected = result.rowCount ?? 0;
+          rows += affected;
+          skipped += 1 - affected;
         } catch (rowErr) {
           if (isConnectionClosed(rowErr)) {
             throw new Error(`[sync-core] ${tableName}: target connection closed mid-sync`);
@@ -289,7 +295,7 @@ export async function syncDirection(
     }
   }
 
-  return { table: tableName, rows: synced, failed, direction };
+  return { table: tableName, rows, skipped, failed, direction };
 }
 
 export async function withClients<T>(

--- a/lib/db/sync-core.ts
+++ b/lib/db/sync-core.ts
@@ -216,6 +216,7 @@ export interface SyncResult {
 }
 
 const BATCH_SIZE = 25;
+const PG_MAX_PARAMS = 65535;
 
 function isConnectionClosed(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -239,6 +240,16 @@ export async function syncDirection(
   const tableName = stripQuotes(table.name);
   const columns = await getColumns(source, table.name);
   if (columns.length === 0) return { table: tableName, rows: 0, skipped: 0, failed: 0, direction };
+
+  // Crash early on impossible state: if a future schema widens to where one
+  // batch would exceed PG's hard parameter limit, the cause would otherwise
+  // surface only on the last (partial) batch of large tables.
+  if (columns.length * BATCH_SIZE > PG_MAX_PARAMS) {
+    throw new Error(
+      `[sync-core] ${tableName}: ${columns.length} cols x BATCH_SIZE ${BATCH_SIZE} ` +
+      `exceeds PG param limit ${PG_MAX_PARAMS}; lower BATCH_SIZE or split the schema`
+    );
+  }
 
   const sourceRows = await source.query(
     `SELECT * FROM ${table.name} ORDER BY ${table.orderBy}`

--- a/scripts/db/sync.ts
+++ b/scripts/db/sync.ts
@@ -48,8 +48,9 @@ function renderCount(n: number | null): string {
 }
 
 function logSyncResult(r: SyncResult) {
+  const skippedSuffix = r.skipped > 0 ? `, ${r.skipped} skipped` : '';
   const failedSuffix = r.failed > 0 ? `, ${r.failed} failed` : '';
-  console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${failedSuffix}`);
+  console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${skippedSuffix}${failedSuffix}`);
 }
 
 function printDashboard(diffs: DiffResult[]) {

--- a/scripts/dev-with-sync.ts
+++ b/scripts/dev-with-sync.ts
@@ -35,15 +35,16 @@ function nextDevArgs(): string[] {
 }
 
 function summarize(label: string, results: SyncResult[]) {
-  const meaningful = results.filter(r => r.rows > 0 || r.failed > 0);
+  const meaningful = results.filter(r => r.rows > 0 || r.skipped > 0 || r.failed > 0);
   if (meaningful.length === 0) {
     console.log(`[sync] ${label}: nothing to transfer`);
     return;
   }
   console.log(`[sync] ${label}:`);
   for (const r of meaningful) {
+    const skippedSuffix = r.skipped > 0 ? `, ${r.skipped} skipped` : '';
     const failedSuffix = r.failed > 0 ? `, ${r.failed} failed` : '';
-    console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${failedSuffix}`);
+    console.log(`  ${r.table}: ${r.rows} rows ${r.direction}${skippedSuffix}${failedSuffix}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaces per-row `INSERT ... VALUES ($1, $2, ...)` with multi-row `INSERT ... VALUES ($1, ...), ($N+1, ...), ...` (batch size 25).
- `syncDirection` slices source rows into batches of 25 and issues one query per batch with `ON CONFLICT ... DO UPDATE WHERE EXCLUDED.ts > target.ts` / `DO NOTHING` preserved per the table's strategy.
- Per-row error granularity becomes per-batch — acceptable trade-off since errors are rare and the next sync retries the same rows.

## Why
Reported: `[sync] startup` consistently times out mid-`text_entries` push with "Connection terminated" / "Client was closed" errors. Root cause is per-row INSERT round-trips over Neon (Japan -> US/EU, ~2-3s per text_entries row because content is large). 30 rows × ~2.5s × pull + push ≈ 150s, well over the 60s wrapper timeout.

After this change, `text_entries` 30 rows = 2 batches = ~5s. Full sync of in-sync state should drop from "timeout at 60s" to "complete in 10-15s".

Param-count and query-size limits are not a concern: 25 rows × ~10 cols max = 250 params (under PG's 65535); 25 × 50KB content = ~1.25MB query (well under PG's 1GB).

## Test plan
- [ ] `npm run dev` on the previously-broken machine completes startup sync within 15s with no `Connection terminated` errors.
- [ ] `npm run db:sync` interactive tool dashboard renders correctly and option 4 (Full sync) produces the same row counts as before.
- [ ] Make a bookmark on PC1, Ctrl+C to push, run `npm run dev` on PC2 -- bookmark appears, no errors.
- [ ] Library page still displays books after sync.