### PR TITLE
feat: production TTS via Google REST API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Google Cloud Translation API
 GOOGLE_TRANSLATE_API_KEY=your_google_translate_api_key_here
 
+# Google Cloud Text-to-Speech (separate API key with the Text-to-Speech API enabled)
+GOOGLE_TTS_API_KEY=your_google_tts_api_key_here
+
 # Database (Development - local PostgreSQL via Docker)
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 POSTGRES_URL=postgresql://user:password@localhost:5432/dbname

--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,11 @@
 GEMINI_API_KEY=your_gemini_api_key_here
 
 # ============================================================================
+# Google Cloud Text-to-Speech (separate API key with the Text-to-Speech API enabled)
+# ============================================================================
+GOOGLE_TTS_API_KEY=your_google_tts_api_key_here
+
+# ============================================================================
 # Local Development Database (Docker Compose)
 # ============================================================================
 # This connects to the PostgreSQL database defined in docker-compose.yml

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -3,28 +3,23 @@ import { TTS_CONFIG } from "@/lib/constants";
 import type { TTSRequest, TTSResponse } from "@/lib/types";
 import { cleanTextForTTS } from "@/lib/utils/ttsTextCleaner";
 
-// Type import only - actual module loaded lazily
-import type { TextToSpeechClient as TTSClientType } from "@google-cloud/text-to-speech";
-
-// Google Cloud TTS クライアント - lazy loaded to save memory
-// The SDK is ~10MB and only loads when TTS is actually used
-let ttsClient: TTSClientType | null = null;
-
-async function getTTSClient(): Promise<TTSClientType> {
-  if (!ttsClient) {
-    // Dynamically import the heavy Google Cloud SDK only when needed
-    const { TextToSpeechClient } = await import("@google-cloud/text-to-speech");
-    ttsClient = new TextToSpeechClient();
-  }
-  return ttsClient;
-}
+const TTS_ENDPOINT = "https://texttospeech.googleapis.com/v1/text:synthesize";
 
 /**
  * Text-to-Speech APIエンドポイント
  * テキストを受け取り、音声データ(base64)を返す
+ * Google Cloud TTS REST APIをAPIキーで直接呼び出す
  */
 export async function POST(request: Request) {
   const startTime = Date.now();
+
+  const apiKey = process.env.GOOGLE_TTS_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { audioContent: '', message: 'GOOGLE_TTS_API_KEY が設定されていません。' },
+      { status: 500 }
+    );
+  }
 
   try {
     const body: TTSRequest = await request.json();
@@ -37,7 +32,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // テキストをTTS用にクリーンアップ
     const cleanedText = cleanTextForTTS(text);
 
     if (!cleanedText) {
@@ -49,35 +43,43 @@ export async function POST(request: Request) {
 
     console.log(`[${new Date().toISOString()}] TTS リクエスト受信 - 文字数: ${cleanedText.length}, 速度: ${speed}, 音声: ${voiceGender}`);
 
-    // 音声名を選択
     const voiceName = voiceGender === 'MALE'
       ? TTS_CONFIG.VOICES.MALE
       : TTS_CONFIG.VOICES.FEMALE;
 
-    const client = await getTTSClient();
-
-    const [response] = await client.synthesizeSpeech({
-      input: { text: cleanedText },
-      voice: {
-        languageCode: TTS_CONFIG.LANGUAGE_CODE,
-        name: voiceName,
-      },
-      audioConfig: {
-        audioEncoding: 'MP3',
-        speakingRate: speed,
-        pitch: 0, // デフォルトピッチ
-      },
+    const response = await fetch(`${TTS_ENDPOINT}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        input: { text: cleanedText },
+        voice: {
+          languageCode: TTS_CONFIG.LANGUAGE_CODE,
+          name: voiceName,
+        },
+        audioConfig: {
+          audioEncoding: 'MP3',
+          speakingRate: speed,
+          pitch: 0,
+        },
+      }),
     });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error('TTS生成中にエラーが発生しました:', response.status, errorBody);
+      return NextResponse.json(
+        { audioContent: '', message: `Google TTS エラー (${response.status})` },
+        { status: 502 }
+      );
+    }
+
+    // REST APIはaudioContentを既にbase64で返すため変換不要
+    const data: { audioContent?: string } = await response.json();
 
     console.log(`[${new Date().toISOString()}] TTS 生成完了。経過時間: ${Date.now() - startTime}ms`);
 
-    // 音声データをbase64に変換
-    const audioContent = response.audioContent
-      ? Buffer.from(response.audioContent).toString('base64')
-      : '';
-
     const result: TTSResponse = {
-      audioContent,
+      audioContent: data.audioContent ?? '',
       message: '音声を生成しました',
     };
 
@@ -86,17 +88,10 @@ export async function POST(request: Request) {
   } catch (error) {
     console.error('TTS生成中にエラーが発生しました:', error);
 
-    // 認証エラーの場合は特別なメッセージ
     const errorMessage = error instanceof Error ? error.message : '不明なエラーが発生しました';
-    const isAuthError = errorMessage.includes('Could not load the default credentials');
 
     return NextResponse.json(
-      {
-        audioContent: '',
-        message: isAuthError
-          ? 'Google Cloud認証が設定されていません。GOOGLE_APPLICATION_CREDENTIALS環境変数を設定してください。'
-          : errorMessage,
-      },
+      { audioContent: '', message: errorMessage },
       { status: 500 }
     );
   }

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -4,6 +4,7 @@ import type { TTSRequest, TTSResponse } from "@/lib/types";
 import { cleanTextForTTS } from "@/lib/utils/ttsTextCleaner";
 
 const TTS_ENDPOINT = "https://texttospeech.googleapis.com/v1/text:synthesize";
+const TTS_TIMEOUT_MS = 15000;
 
 /**
  * Text-to-Speech APIエンドポイント
@@ -46,10 +47,15 @@ export async function POST(request: Request) {
     const voiceName = voiceGender === 'MALE'
       ? TTS_CONFIG.VOICES.MALE
       : TTS_CONFIG.VOICES.FEMALE;
+    const speakingRate = Math.min(TTS_CONFIG.MAX_SPEED, Math.max(TTS_CONFIG.MIN_SPEED, speed));
 
-    const response = await fetch(`${TTS_ENDPOINT}?key=${apiKey}`, {
+    const response = await fetch(TTS_ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+      },
+      signal: AbortSignal.timeout(TTS_TIMEOUT_MS),
       body: JSON.stringify({
         input: { text: cleanedText },
         voice: {
@@ -58,7 +64,7 @@ export async function POST(request: Request) {
         },
         audioConfig: {
           audioEncoding: 'MP3',
-          speakingRate: speed,
+          speakingRate,
           pitch: 0,
         },
       }),
@@ -87,6 +93,13 @@ export async function POST(request: Request) {
 
   } catch (error) {
     console.error('TTS生成中にエラーが発生しました:', error);
+
+    if (error instanceof Error && error.name === 'TimeoutError') {
+      return NextResponse.json(
+        { audioContent: '', message: 'Google TTS がタイムアウトしました' },
+        { status: 504 }
+      );
+    }
 
     const errorMessage = error instanceof Error ? error.message : '不明なエラーが発生しました';
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -35,6 +35,10 @@ export default $config({
       name: `${ssmPrefix}-GOOGLE_TRANSLATE_API_KEY`,
       withDecryption: true,
     });
+    const googleTtsApiKey = await aws.ssm.getParameter({
+      name: `${ssmPrefix}-GOOGLE_TTS_API_KEY`,
+      withDecryption: true,
+    });
 
     const web = new sst.aws.Nextjs("JapaneseReadHelper", {
       openNextVersion: "3.4.1",
@@ -44,6 +48,7 @@ export default $config({
         DATABASE_URL: databaseUrl.value,
         POSTGRES_URL: databaseUrl.value,
         GOOGLE_TRANSLATE_API_KEY: googleTranslateApiKey.value,
+        GOOGLE_TTS_API_KEY: googleTtsApiKey.value,
       },
       warm: 1,
     });


### PR DESCRIPTION
Makes Text-to-Speech work in production (Lambda) by calling the Google Cloud TTS **REST API with an API key** instead of the `@google-cloud/text-to-speech` SDK, which relies on Application Default Credentials that are painful to provide in serverless. This is what lights up the audiobook (merged in #30) and the per-sentence TTS button for production users.

## Changes
- `app/api/tts/route.ts`: POST to `texttospeech.googleapis.com/v1/text:synthesize?key=$GOOGLE_TTS_API_KEY`; returns Google's base64 `audioContent` directly. 502 on Google errors, 500 if the key is unset. Drops the lazy-loaded SDK client.
- `sst.config.ts`: reads SSM `japanese-read-helper-{stage}-GOOGLE_TTS_API_KEY` (SecureString) and injects it as the Lambda env var `GOOGLE_TTS_API_KEY`.
- `.env.example` / `.env.local.example`: document `GOOGLE_TTS_API_KEY`.

## REQUIRED before merge (or the deploy fails)
`sst.config.ts` calls `aws.ssm.getParameter(...GOOGLE_TTS_API_KEY)`, which throws if the parameter is missing - that fails the **entire** deploy, not just TTS. Create it first:

```bash
aws ssm put-parameter \
  --name "japanese-read-helper-production-GOOGLE_TTS_API_KEY" \
  --value "<your TTS api key>" \
  --type SecureString \
  --region ap-northeast-1
```

Use the same key that works in your `.env.local`; restrict it to the Text-to-Speech API in the Google Cloud console.

## Also check
- **IAM**: the deploy user (`AWS_ACCESS_KEY_ID`) needs `ssm:GetParameter` on the new param. A wildcard policy (`.../parameter/japanese-read-helper-production-*`) covers it; if params are listed explicitly, add this one.
- **Cost**: ~1M chars/month free, then ~$16/M for Neural2 voices. Worth a GCP budget alert since the audiobook can synthesize whole books.

## Notes
- `@google-cloud/text-to-speech` is now unused and can be dropped from `package.json` in a follow-up (~10MB Lambda slim).
- `tsc --noEmit` clean. Already verified working locally via the audiobook.