### PR TITLE
fix: silence markdown parser log spam + harden audiobook TTS failures

### DIFF
--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -169,6 +169,20 @@ export function useAudioBook({
     playStepRef.current(next, true);
   }, [updateStatus]);
 
+  // A clip failing (fetch error or decode/play error) is per-clip and usually transient,
+  // so skip and keep going while under the limit; only stop once failures pile up.
+  const skipOrEndOnFailure = useCallback((token: number) => {
+    if (token !== playTokenRef.current) return;
+    if (isAutoRef.current && consecutiveFailuresRef.current < MAX_CONSECUTIVE_FAILURES) {
+      consecutiveFailuresRef.current += 1;
+      advanceAfter(token);
+      return;
+    }
+    consecutiveFailuresRef.current = 0;
+    isAutoRef.current = false;
+    updateStatus('idle');
+  }, [advanceAfter, updateStatus]);
+
   const playStep = useCallback(async (step: PlayStep, isAuto: boolean) => {
     const units2 = unitsRef.current;
     if (step.index < 0 || step.index >= units2.length) return;
@@ -188,15 +202,7 @@ export function useAudioBook({
     } catch (error) {
       if (token !== playTokenRef.current) return;
       console.error('Audiobook TTS fetch failed:', error);
-      // Skip a few bad clips rather than ending the whole session on one transient failure.
-      if (isAutoRef.current && consecutiveFailuresRef.current < MAX_CONSECUTIVE_FAILURES) {
-        consecutiveFailuresRef.current += 1;
-        advanceAfter(token);
-        return;
-      }
-      consecutiveFailuresRef.current = 0;
-      isAutoRef.current = false;
-      updateStatus('idle');
+      skipOrEndOnFailure(token);
       return;
     }
     if (token !== playTokenRef.current) return;
@@ -213,8 +219,8 @@ export function useAudioBook({
     audio.onended = () => advanceAfter(token);
     audio.onerror = () => {
       if (token !== playTokenRef.current) return;
-      isAutoRef.current = false;
-      updateStatus('idle');
+      console.error('Audiobook clip failed to decode/play');
+      skipOrEndOnFailure(token);
     };
     audioRef.current = audio;
 
@@ -232,7 +238,7 @@ export function useAudioBook({
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
     prefetch(step);
-  }, [advanceAfter, clearStartCursor, detachAudio, prefetch, updateIndex, updateStatus]);
+  }, [advanceAfter, clearStartCursor, detachAudio, prefetch, skipOrEndOnFailure, updateIndex, updateStatus]);
 
   useEffect(() => { playStepRef.current = playStep; }, [playStep]);
 
@@ -250,8 +256,17 @@ export function useAudioBook({
 
   const resume = useCallback(() => {
     if (statusRef.current !== 'paused') return;
-    audioRef.current?.play().catch(() => {});
-    updateStatus('playing');
+    const audio = audioRef.current;
+    if (!audio) {
+      updateStatus('idle');
+      return;
+    }
+    audio.play()
+      .then(() => updateStatus('playing'))
+      .catch((error) => {
+        console.error('Audiobook resume failed:', error);
+        updateStatus('idle');
+      });
   }, [updateStatus]);
 
   const stop = useCallback(() => {

--- a/lib/utils/markdownParser/index.ts
+++ b/lib/utils/markdownParser/index.ts
@@ -9,6 +9,7 @@ import {
   isEmptyLineBeforeSubItems,
   isStandaloneHeading,
   isOrphanedDialogue,
+  isAiMetaLine,
 } from './validator';
 import {
   removeHeadingPrefix,
@@ -138,7 +139,7 @@ export function parseMarkdown(text: string, isError: boolean = false): ParsedIte
         else if (isOrphanedDialogue(line)) {
           console.warn('Orphaned dialogue detected:', line);
         }
-        else {
+        else if (!isAiMetaLine(line)) {
           console.log('Unexpected line format:', line);
         }
       }

--- a/lib/utils/markdownParser/validator.ts
+++ b/lib/utils/markdownParser/validator.ts
@@ -138,3 +138,34 @@ export function isOrphanedDialogue(line: string): boolean {
   // 日本語の対話マーカーを含む場合は孤立した対話の可能性がある
   return DIALOGUE_MARKERS.some((marker) => line.includes(marker));
 }
+
+/**
+ * AIが整形フォーマット（< 原文 >> 要約）の外で出力する非コンテンツ行かどうかを確認します
+ * （区切り線、編集注記、要約作業そのものを説明する前置き文）
+ * これらは表示対象ではなく、警告ログからも除外する
+ */
+export function isAiMetaLine(line: string): boolean {
+  // ルビは語単位で分割されるため、アンカー語（「日本語学習者」など）が
+  // タグで途切れないよう、判定前に振り仮名を除いた素の本文に戻す
+  const plain = line
+    .replace(/<rt>.*?<\/rt>/g, '')
+    .replace(/<\/?(?:ruby|rb)>/g, '')
+    .trim();
+  if (plain === '') {
+    return false;
+  }
+  // 区切り線（---、*** など）
+  if (/^[-―ー─_*]{3,}$/.test(plain)) {
+    return true;
+  }
+  // 全体が括弧で囲まれた編集注記（（※中略：...） など）
+  if (/^[（(].*※.*[)）]$/.test(plain)) {
+    return true;
+  }
+  // 要約作業そのものを説明するAIの前置き文。
+  // 「ご提示」「日本語学習者」はプロンプト由来の語で本文には現れないため、
+  // 「要約」を含む一般的な地の文を誤って巻き込まないようアンカーとして併用する
+  const hasPreambleAnchor = /ご提示|日本語学習者/.test(plain);
+  const describesSummaryTask = /要約|平易化/.test(plain);
+  return hasPreambleAnchor && describesSummaryTask;
+}

--- a/lib/utils/ttsCache.ts
+++ b/lib/utils/ttsCache.ts
@@ -50,9 +50,13 @@ async function synthesize({ text, speed, voiceGender }: FetchTTSParams): Promise
  * Concurrent requests for the same key share a single network call.
  */
 export async function fetchTTS(params: FetchTTSParams): Promise<string | null> {
-  if (!cleanTextForTTS(params.text)) return null;
+  const cleanedText = cleanTextForTTS(params.text);
+  if (!cleanedText) return null;
 
-  const key = cacheKey(params);
+  // Key and synthesize on the cleaned text so inputs differing only in furigana/whitespace
+  // hit the same cache entry and the server is not asked to clean it a second time.
+  const cleanedParams = { ...params, text: cleanedText };
+  const key = cacheKey(cleanedParams);
   const cached = audioByKey.get(key);
   if (cached) {
     rememberAudio(key, cached);
@@ -62,7 +66,7 @@ export async function fetchTTS(params: FetchTTSParams): Promise<string | null> {
   const pending = inFlightByKey.get(key);
   if (pending) return pending;
 
-  const request = synthesize(params)
+  const request = synthesize(cleanedParams)
     .then((audioBase64) => {
       inFlightByKey.delete(key);
       rememberAudio(key, audioBase64);


### PR DESCRIPTION
Re-applies the fixes from #31 directly on top of the current `main`. #31 was branched from the audiobook feature tip before that feature merged, so its diff was a stale 22-commit duplicate that conflicted with `main`. This branch carries only the four fixes (+69/-18, 4 files) and merges cleanly.

## Fixes

1. **Silence `Unexpected line format` console spam** (`markdownParser`) — the Gemini rephrase step emits non-content lines outside the `< original >> summary` format (self-referential preamble, `---` rules, `（※...）` notes) that leak into the stored files. New `isAiMetaLine()` recognizes them (anchored to prompt-only phrases `ご提示`/`日本語学習者` + `要約`/`平易化`, with ruby stripped first so the anchors survive furigana tags) and skips the diagnostic log; genuinely malformed lines still log. This is the original reported bug.

2. **[Important] Un-decodable audio clip no longer ends the whole session** (`useAudioBook`) — `audio.onerror` now routes through a shared `skipOrEndOnFailure(token)` that skips-and-continues (bounded by `MAX_CONSECUTIVE_FAILURES`) exactly like a fetch failure, instead of dropping to `idle`.

3. **`resume()` no longer lies about status** — sets `playing` only on a resolved `play()`; a rejection (or missing element) logs and falls to `idle`.

4. **TTS cache key on cleaned text** (`ttsCache`) — clean once, key + synthesize on the cleaned text, so furigana/whitespace-only variants share a cache entry and the server clean is an idempotent no-op.

## Notes

- `next lint` passes (no new warnings/errors).
- Four deferred review suggestions tracked in #33.
- Supersedes #31 (will close it).
