### PR TITLE
feat: guest preview access to a few public books

### DIFF
--- a/app/api/books/route.ts
+++ b/app/api/books/route.ts
@@ -7,10 +7,15 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getBooks, createBook } from '@/lib/db/bookQueries.sql';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const fileName = searchParams.get('fileName') || undefined;
@@ -31,6 +36,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
     const {

--- a/app/api/explain-sentence/route.ts
+++ b/app/api/explain-sentence/route.ts
@@ -7,7 +7,8 @@ import {
   ai_instructions_speaker,
   ai_instructions_narrative,
 } from "@/lib/ai";
-import { AI_MODELS, EXPLANATION_MODES } from "@/lib/constants";
+import { AI_MODELS, EXPLANATION_MODES, GUEST_KEY_HEADERS } from "@/lib/constants";
+import { isAuthenticated } from "@/lib/auth/apiSession";
 import type { ExplanationRequest, ExplanationResponse } from "@/lib/types";
 
 /**
@@ -18,6 +19,15 @@ export async function POST(request: Request) {
   const startTime = Date.now();
 
   try {
+    const authed = await isAuthenticated();
+    const guestKey = request.headers.get(GUEST_KEY_HEADERS.GEMINI);
+    if (!authed && !guestKey) {
+      return NextResponse.json(
+        { explanation: '', message: 'Sign in or add your own Gemini API key.', requiresGuestKey: 'gemini' },
+        { status: 401 }
+      );
+    }
+
     const body: ExplanationRequest = await request.json();
     const { sentence, context, fileName, contextSize, mode } = body;
 
@@ -54,8 +64,8 @@ ${sentence}`
 
 ${sentence}`;
 
-    // Gemini APIを呼び出し (singleton client)
-    const ai = getAIClient();
+    // Gemini APIを呼び出し (guests use their own key, never the owner's)
+    const ai = getAIClient(authed ? undefined : guestKey || undefined);
 
     const aiCallStartTime = Date.now();
     const response = await ai.models.generateContent({

--- a/app/api/gemini-api/route.ts
+++ b/app/api/gemini-api/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from "next/server";
 import { getAIClient } from "@/lib/ai";
+import { isAuthenticated } from "@/lib/auth/apiSession";
 
 // 5MB limit to prevent OOM on 512MB Lightsail instance
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
 export async function POST(request: Request) {
   const startTime = Date.now();
+
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ response: "", message: "Sign in required" }, { status: 401 });
+  }
 
   const ai = getAIClient();
   let response;

--- a/app/api/library-progress/route.ts
+++ b/app/api/library-progress/route.ts
@@ -110,8 +110,12 @@ export async function GET() {
     for (const row of rows) {
       const key = `${row.directory}/${row.file_name}`;
       const itemCount = countItems(row.content || '');
-      const totalPages = Math.ceil(itemCount / PAGINATION_CONFIG.ITEMS_PER_PAGE);
-      const totalCharacters = (row.content || '').length;
+      const fullPages = Math.ceil(itemCount / PAGINATION_CONFIG.ITEMS_PER_PAGE);
+      // Guests only see the preview, so their card reflects the capped page count
+      // and does not disclose the full work's length.
+      const previewBook = authed ? null : findPublicBook(row.directory, row.file_name);
+      const totalPages = previewBook ? Math.min(fullPages, previewBook.maxPreviewPages) : fullPages;
+      const totalCharacters = previewBook ? 0 : (row.content || '').length;
       const bookmarkPage = authed ? row.bookmark_page || null : null;
 
       let progress = 0;

--- a/app/api/library-progress/route.ts
+++ b/app/api/library-progress/route.ts
@@ -3,6 +3,8 @@ import { sql } from '@/lib/db/connection';
 import { parseMarkdown } from '@/lib/utils/markdownParser';
 import { stripFurigana } from '@/lib/utils/furiganaParser';
 import { READER_CONFIG, PAGINATION_CONFIG } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
+import { findPublicBook } from '@/lib/publicBooks';
 
 export const dynamic = 'force-dynamic';
 
@@ -76,6 +78,8 @@ function countItems(content: string): number {
 
 export async function GET() {
   try {
+    const authed = await isAuthenticated();
+
     const result = await sql`
       SELECT
         t.file_name,
@@ -88,12 +92,18 @@ export async function GET() {
       LEFT JOIN bookmarks b ON t.file_name = b.file_name AND t.directory = b.directory
     `;
 
-    const rows = normalizeResult<EntryRow>(result);
+    const allRows = normalizeResult<EntryRow>(result);
+    // Guests only see allowlisted books, and never the owner's reading position.
+    const rows = authed
+      ? allRows
+      : allRows.filter((row) => findPublicBook(row.directory, row.file_name));
     const progressData: ProgressResponse = {};
 
-    for (const row of rows) {
-      if (row.content && row.bookmark_text) {
-        row.bookmark_page = calculatePageFromText(row.bookmark_text, row.content);
+    if (authed) {
+      for (const row of rows) {
+        if (row.content && row.bookmark_text) {
+          row.bookmark_page = calculatePageFromText(row.bookmark_text, row.content);
+        }
       }
     }
 
@@ -102,7 +112,7 @@ export async function GET() {
       const itemCount = countItems(row.content || '');
       const totalPages = Math.ceil(itemCount / PAGINATION_CONFIG.ITEMS_PER_PAGE);
       const totalCharacters = (row.content || '').length;
-      const bookmarkPage = row.bookmark_page || null;
+      const bookmarkPage = authed ? row.bookmark_page || null : null;
 
       let progress = 0;
       if (bookmarkPage && totalPages > 0) {
@@ -114,7 +124,7 @@ export async function GET() {
         totalCharacters: totalCharacters,
         bookmarkPage,
         totalPages,
-        bookmarkUpdatedAt: row.bookmark_updated_at || null,
+        bookmarkUpdatedAt: authed ? row.bookmark_updated_at || null : null,
         createdAt: row.created_at || null,
       };
     }

--- a/app/api/list-text-files/route.ts
+++ b/app/api/list-text-files/route.ts
@@ -1,10 +1,27 @@
 import { NextResponse } from 'next/server';
 import { getAllTextEntries } from '@/lib/db/queries';
-import type { TextFileListResponse } from '@/lib/types';
+import { isAuthenticated } from '@/lib/auth/apiSession';
+import { PUBLIC_BOOKS } from '@/lib/publicBooks';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {
+    const authed = await isAuthenticated();
     const { directories, filesByDirectory } = await getAllTextEntries();
+
+    if (!authed) {
+      const available = PUBLIC_BOOKS.filter((book) =>
+        (filesByDirectory[book.directory] || []).includes(book.fileName)
+      );
+      return NextResponse.json({
+        directories: available.map((book) => book.directory),
+        filesByDirectory: Object.fromEntries(
+          available.map((book) => [book.directory, [book.fileName]])
+        ),
+        files: available.map((book) => `${book.directory}/${book.fileName}`),
+      });
+    }
 
     const flatFiles: string[] = [];
     directories.forEach(dir => {

--- a/app/api/read-bookmark/route.ts
+++ b/app/api/read-bookmark/route.ts
@@ -6,6 +6,7 @@
 import { NextResponse } from 'next/server';
 import { getBookmark } from '@/lib/db/queries';
 import { DEFAULT_FILE_NAME } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 import type { BookmarkResponse } from '@/lib/types';
 
 // Mark as dynamic to prevent static generation during build
@@ -20,6 +21,11 @@ export async function GET(request: Request): Promise<NextResponse<BookmarkRespon
   if (!fileName || fileName.includes('..')) {
     console.error(`無効なファイル名: "${fileName}"`);
     return NextResponse.json({ text: '' }, { status: 400 });
+  }
+
+  // Guests have no personal bookmarks; do not expose the owner's saved position.
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ text: '' });
   }
 
   try {

--- a/app/api/read-public-txt/route.ts
+++ b/app/api/read-public-txt/route.ts
@@ -6,7 +6,12 @@
 import { NextResponse } from 'next/server';
 import { getTextEntry } from '@/lib/db/queries';
 import { DEFAULT_FILE_NAME } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
+import { findPublicBookByPath } from '@/lib/publicBooks';
+import { truncateToPreviewPages } from '@/lib/utils/truncatePreview';
 import type { TextResponse } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request): Promise<NextResponse<TextResponse>> {
   try {
@@ -30,6 +35,15 @@ export async function GET(request: Request): Promise<NextResponse<TextResponse>>
     // URL format: /api/read-public-txt?directory=bookv2-furigana/subdir&fileName=file-name
     // OR legacy: /api/read-public-txt?fileName=dir/file-name
     let directory = searchParams.get('directory');
+
+    // Guests may only read allowlisted books, and only a short page preview.
+    const requestedPath = directory ? `${directory}/${fileName}` : fileName;
+    const authed = await isAuthenticated();
+    const publicBook = authed ? null : findPublicBookByPath(requestedPath);
+    if (!authed && !publicBook) {
+      return NextResponse.json({ text: '' }, { status: 403 });
+    }
+
     let file: string;
     let content = '';
 
@@ -67,7 +81,11 @@ export async function GET(request: Request): Promise<NextResponse<TextResponse>>
 
     console.log(`テキストエントリ読み込み (データベース): fileName="${fileName}", directory="${directory}", length=${content.length}`);
 
-    return NextResponse.json({ text: content });
+    const text = publicBook
+      ? truncateToPreviewPages(content, publicBook.maxPreviewPages)
+      : content;
+
+    return NextResponse.json({ text });
   } catch (error) {
     console.error('テキストファイルの読み込み中にエラーが発生しました:', error);
     console.error('エラー詳細:', error instanceof Error ? error.message : String(error));

--- a/app/api/ruby-registry/route.ts
+++ b/app/api/ruby-registry/route.ts
@@ -6,6 +6,7 @@ import {
   ignoreSuggestion
 } from '@/lib/services/fileService';
 import { isAuthenticated } from '@/lib/auth/apiSession';
+import { isPublicDirectory } from '@/lib/publicBooks';
 import type { RubyRegistryResponse, RubyEntry } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -27,6 +28,11 @@ export async function GET(request: Request): Promise<NextResponse<RubyRegistryRe
       success: false,
       message: 'Invalid path'
     }, { status: 400 });
+  }
+
+  // Guests may only read the vocabulary index of allowlisted preview books.
+  if (!(await isAuthenticated()) && !isPublicDirectory(`${directory}/${bookName}`)) {
+    return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 403 });
   }
 
   try {

--- a/app/api/ruby-registry/route.ts
+++ b/app/api/ruby-registry/route.ts
@@ -5,6 +5,7 @@ import {
   deleteRubyEntry,
   ignoreSuggestion
 } from '@/lib/services/fileService';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 import type { RubyRegistryResponse, RubyEntry } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -57,6 +58,10 @@ export async function GET(request: Request): Promise<NextResponse<RubyRegistryRe
 }
 
 export async function POST(request: Request): Promise<NextResponse<RubyRegistryResponse>> {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ success: false, message: 'Sign in required' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
     const { directory, bookName, entry } = body as {
@@ -100,6 +105,10 @@ export async function POST(request: Request): Promise<NextResponse<RubyRegistryR
 }
 
 export async function DELETE(request: Request): Promise<NextResponse<RubyRegistryResponse>> {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ success: false, message: 'Sign in required' }, { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
   const directory = searchParams.get('directory');
   const bookName = searchParams.get('bookName');

--- a/app/api/ruby-registry/route.ts
+++ b/app/api/ruby-registry/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: Request): Promise<NextResponse<RubyRegistryRe
     }, { status: 400 });
   }
 
-  // Guests may only read the vocabulary index of allowlisted preview books.
+  // Guests may read the vocabulary index of an allowlisted preview book. This is
+  // the whole-book ruby registry (a kanji->reading index), intentionally not
+  // capped to the 5-page text preview -- it is derived metadata, not prose.
   if (!(await isAuthenticated()) && !isPublicDirectory(`${directory}/${bookName}`)) {
     return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 403 });
   }

--- a/app/api/text-entries/reset/route.ts
+++ b/app/api/text-entries/reset/route.ts
@@ -6,6 +6,7 @@
 import { NextResponse } from 'next/server';
 import { resetTextEntries, upsertTextEntry } from '@/lib/db/queries';
 import { listTextFiles, readTextFile } from '@/lib/services/fileService';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 
 // Mark as dynamic to prevent static generation during build
 export const dynamic = 'force-dynamic';
@@ -17,6 +18,10 @@ export const dynamic = 'force-dynamic';
  * - If remigrate=true, re-migrates all files from filesystem after reset
  */
 export async function POST(request: Request) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
   const confirm = searchParams.get('confirm') === 'true';
   const remigrate = searchParams.get('remigrate') === 'true';

--- a/app/api/text-entries/route.ts
+++ b/app/api/text-entries/route.ts
@@ -11,6 +11,9 @@ import {
   upsertTextEntry
 } from '@/lib/db/queries';
 import { readTextFile } from '@/lib/services/fileService';
+import { isAuthenticated } from '@/lib/auth/apiSession';
+import { findPublicBook } from '@/lib/publicBooks';
+import { truncateToPreviewPages } from '@/lib/utils/truncatePreview';
 
 // Mark as dynamic to prevent static generation during build
 export const dynamic = 'force-dynamic';
@@ -25,6 +28,8 @@ export async function GET(request: Request) {
   const directory = searchParams.get('directory');
 
   try {
+    const authed = await isAuthenticated();
+
     // If fileName and directory are provided, get specific entry
     if (fileName && directory) {
       // Validation (prevent directory traversal attacks)
@@ -35,14 +40,27 @@ export async function GET(request: Request) {
         );
       }
 
+      // Guests may only read allowlisted books, capped to the preview length.
+      const publicBook = authed ? null : findPublicBook(directory, fileName);
+      if (!authed && !publicBook) {
+        return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 403 });
+      }
+
       const content = await getTextEntry(fileName, directory);
+      const data = publicBook
+        ? truncateToPreviewPages(content, publicBook.maxPreviewPages)
+        : content;
       return NextResponse.json({
         success: true,
-        data: { fileName, directory, content }
+        data: { fileName, directory, content: data }
       });
     }
 
-    // Otherwise, return all entries
+    // Listing every entry is owner-only.
+    if (!authed) {
+      return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 403 });
+    }
+
     const allEntries = await getAllTextEntries();
     return NextResponse.json({
       success: true,

--- a/app/api/text-entries/route.ts
+++ b/app/api/text-entries/route.ts
@@ -84,6 +84,10 @@ export async function GET(request: Request) {
  * Remove specific text entry from database
  */
 export async function DELETE(request: Request) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
   const fileName = searchParams.get('fileName');
   const directory = searchParams.get('directory');

--- a/app/api/translate/route.ts
+++ b/app/api/translate/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { GUEST_KEY_HEADERS } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 
 export async function POST(request: NextRequest) {
   try {
@@ -8,7 +10,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Text is required' }, { status: 400 });
     }
 
-    const apiKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+    const authed = await isAuthenticated();
+    const guestKey = request.headers.get(GUEST_KEY_HEADERS.TRANSLATE);
+    if (!authed && !guestKey) {
+      return NextResponse.json(
+        { error: 'Sign in or add your own Google Translate API key.', requiresGuestKey: 'translate' },
+        { status: 401 }
+      );
+    }
+
+    // Guests use their own key; the owner's key is never used for a guest request.
+    const apiKey = authed ? process.env.GOOGLE_TRANSLATE_API_KEY : guestKey;
     if (!apiKey) {
       console.error('GOOGLE_TRANSLATE_API_KEY not configured');
       return NextResponse.json({ error: 'Translation service not configured' }, { status: 500 });

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { TTS_CONFIG } from "@/lib/constants";
+import { TTS_CONFIG, GUEST_KEY_HEADERS } from "@/lib/constants";
+import { isAuthenticated } from "@/lib/auth/apiSession";
 import type { TTSRequest, TTSResponse } from "@/lib/types";
 import { cleanTextForTTS } from "@/lib/utils/ttsTextCleaner";
 
@@ -14,7 +15,17 @@ const TTS_TIMEOUT_MS = 15000;
 export async function POST(request: Request) {
   const startTime = Date.now();
 
-  const apiKey = process.env.GOOGLE_TTS_API_KEY;
+  const authed = await isAuthenticated();
+  const guestKey = request.headers.get(GUEST_KEY_HEADERS.TTS);
+  if (!authed && !guestKey) {
+    return NextResponse.json(
+      { audioContent: '', message: 'Sign in or add your own Google TTS API key.', requiresGuestKey: 'tts' },
+      { status: 401 }
+    );
+  }
+
+  // Guests use their own key; the owner's key is never used for a guest request.
+  const apiKey = authed ? process.env.GOOGLE_TTS_API_KEY : guestKey;
   if (!apiKey) {
     return NextResponse.json(
       { audioContent: '', message: 'GOOGLE_TTS_API_KEY が設定されていません。' },

--- a/app/api/vocabulary/route.ts
+++ b/app/api/vocabulary/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server';
 import { getVocabularyEntries, createVocabularyEntry } from '@/lib/db/vocabularyQueries.sql';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 
 export async function GET(request: Request) {
   try {
+    if (!(await isAuthenticated())) {
+      return NextResponse.json({ success: true, entries: [], count: 0 });
+    }
+
     const { searchParams } = new URL(request.url);
     const word = searchParams.get('word') || undefined;
     const fileName = searchParams.get('fileName') || undefined;
@@ -32,6 +37,13 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    if (!(await isAuthenticated())) {
+      return NextResponse.json(
+        { success: false, message: 'Sign in required' },
+        { status: 401 }
+      );
+    }
+
     const body = await request.json();
     const { word, reading, sentence, fileName, directory, paragraphText, notes } = body;
 

--- a/app/api/write-bookmark/route.ts
+++ b/app/api/write-bookmark/route.ts
@@ -5,12 +5,17 @@
 
 import { NextResponse } from 'next/server';
 import { upsertBookmark } from '@/lib/db/queries';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 import type { BookmarkRequest, WriteResponse } from '@/lib/types';
 
 // Mark as dynamic to prevent static generation during build
 export const dynamic = 'force-dynamic';
 
 export async function POST(request: Request): Promise<NextResponse<WriteResponse>> {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ message: 'Sign in required' }, { status: 401 });
+  }
+
   if (request.headers.get('content-type') !== 'application/json') {
     return NextResponse.json(
       { message: '無効なContent-Typeです' },

--- a/app/api/write-public-txt-ai/route.ts
+++ b/app/api/write-public-txt-ai/route.ts
@@ -8,6 +8,7 @@ import { NextResponse } from 'next/server';
 import { generateGeminiContent, ai_instructions } from '@/lib/ai';
 import { upsertTextEntry } from '@/lib/db/queries';
 import { DEFAULT_TEXT_FILES, MAX_CHUNK_SIZE, AI_MODELS } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 import type { TextRequest, WriteResponse } from '@/lib/types';
 
 /**
@@ -41,6 +42,10 @@ function splitTextIntoChunks(text: string, maxChars: number): string[][] {
 }
 
 export async function POST(request: Request): Promise<NextResponse<WriteResponse>> {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ message: 'Sign in required', success: false }, { status: 401 });
+  }
+
   try {
     const { text }: TextRequest = await request.json();
 

--- a/app/api/write-public-txt/route.ts
+++ b/app/api/write-public-txt/route.ts
@@ -6,9 +6,14 @@
 import { NextResponse } from 'next/server';
 import { upsertTextEntry } from '@/lib/db/queries';
 import { DEFAULT_TEXT_FILES } from '@/lib/constants';
+import { isAuthenticated } from '@/lib/auth/apiSession';
 import type { TextRequest, WriteResponse } from '@/lib/types';
 
 export async function POST(request: Request): Promise<NextResponse<WriteResponse>> {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ message: 'Sign in required' }, { status: 401 });
+  }
+
   try {
     const { text }: TextRequest = await request.json();
 

--- a/app/components/reading/CollapsibleItem.tsx
+++ b/app/components/reading/CollapsibleItem.tsx
@@ -10,7 +10,7 @@ import TTSButton from "@/app/components/reading/TTSButton";
 import { useSearchParams } from "next/navigation";
 import { COLORS, EXPLANATION_CONFIG, DARK_COLORS } from "@/lib/constants";
 import { parseFurigana, segmentsToHTML } from "@/lib/utils/furiganaParser";
-import { guestKeyHeaders, promptGuestKey } from "@/lib/guestKeys";
+import { guestKeyHeaders, promptGuestKeyOnFailure } from "@/lib/guestKeys";
 
 const IMAGE_PATTERN = /\[IMAGE:([^\]]+)\]/;
 
@@ -231,13 +231,7 @@ const CollapsibleItem: React.FC<CollapsibleItemProps> = ({
       });
 
       if (!response.ok) {
-        if (response.status === 401) {
-          const info = await response.json().catch(() => null);
-          if (info?.requiresGuestKey === "translate") {
-            promptGuestKey("translate");
-            return;
-          }
-        }
+        await promptGuestKeyOnFailure("translate", response);
         throw new Error("Translation failed");
       }
 

--- a/app/components/reading/CollapsibleItem.tsx
+++ b/app/components/reading/CollapsibleItem.tsx
@@ -10,6 +10,7 @@ import TTSButton from "@/app/components/reading/TTSButton";
 import { useSearchParams } from "next/navigation";
 import { COLORS, EXPLANATION_CONFIG, DARK_COLORS } from "@/lib/constants";
 import { parseFurigana, segmentsToHTML } from "@/lib/utils/furiganaParser";
+import { guestKeyHeaders, promptGuestKey } from "@/lib/guestKeys";
 
 const IMAGE_PATTERN = /\[IMAGE:([^\]]+)\]/;
 
@@ -224,11 +225,19 @@ const CollapsibleItem: React.FC<CollapsibleItemProps> = ({
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...guestKeyHeaders("translate"),
         },
         body: JSON.stringify({ text: head }),
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          const info = await response.json().catch(() => null);
+          if (info?.requiresGuestKey === "translate") {
+            promptGuestKey("translate");
+            return;
+          }
+        }
         throw new Error("Translation failed");
       }
 

--- a/app/components/reading/ExplanationSidebar.tsx
+++ b/app/components/reading/ExplanationSidebar.tsx
@@ -5,7 +5,7 @@ import { marked } from 'marked';
 import { API_ROUTES, EXPLANATION_CONFIG, EXPLANATION_MODE_CONFIG } from '@/lib/constants';
 import { useExplanationCache } from '@/app/hooks/useExplanationCache';
 import { parseFurigana, segmentsToHTML, stripFurigana } from '@/lib/utils/furiganaParser';
-import { guestKeyHeaders, promptGuestKey, GUEST_KEY_UPDATED_EVENT } from '@/lib/guestKeys';
+import { guestKeyHeaders, promptGuestKeyOnFailure, GUEST_KEY_UPDATED_EVENT } from '@/lib/guestKeys';
 import type { ExplanationRequest, ExplanationResponse } from '@/lib/types';
 import type { ExplanationMode } from '@/lib/constants';
 
@@ -141,14 +141,12 @@ export default function ExplanationSidebar({
         });
 
         if (!response.ok) {
-          if (response.status === 401) {
-            const info = await response.json().catch(() => null);
-            if (info?.requiresGuestKey === 'gemini') {
-              promptGuestKey('gemini');
-              throw new Error('Guest mode: add your own Gemini API key to use AI explanations.');
-            }
-          }
-          throw new Error(`Failed to fetch explanation: ${response.statusText}`);
+          const prompted = await promptGuestKeyOnFailure('gemini', response);
+          throw new Error(
+            prompted
+              ? 'Guest mode: add or update your Gemini API key to use AI explanations.'
+              : `Failed to fetch explanation: ${response.statusText}`
+          );
         }
 
         const data: ExplanationResponse = await response.json();

--- a/app/components/reading/ExplanationSidebar.tsx
+++ b/app/components/reading/ExplanationSidebar.tsx
@@ -5,6 +5,7 @@ import { marked } from 'marked';
 import { API_ROUTES, EXPLANATION_CONFIG, EXPLANATION_MODE_CONFIG } from '@/lib/constants';
 import { useExplanationCache } from '@/app/hooks/useExplanationCache';
 import { parseFurigana, segmentsToHTML, stripFurigana } from '@/lib/utils/furiganaParser';
+import { guestKeyHeaders, promptGuestKey, GUEST_KEY_UPDATED_EVENT } from '@/lib/guestKeys';
 import type { ExplanationRequest, ExplanationResponse } from '@/lib/types';
 import type { ExplanationMode } from '@/lib/constants';
 
@@ -60,6 +61,15 @@ export default function ExplanationSidebar({
       document.removeEventListener('keydown', handleEscKey);
     };
   }, [isOpen, onClose]);
+
+  // After a guest saves their API key, retry the explanation automatically.
+  React.useEffect(() => {
+    const handleKeyUpdated = () => {
+      if (isOpen) setForceRegenerate(true);
+    };
+    window.addEventListener(GUEST_KEY_UPDATED_EVENT, handleKeyUpdated);
+    return () => window.removeEventListener(GUEST_KEY_UPDATED_EVENT, handleKeyUpdated);
+  }, [isOpen]);
 
   const handleTouchStart = (e: React.TouchEvent) => {
     setTouchStart(e.targetTouches[0].clientX);
@@ -126,11 +136,18 @@ export default function ExplanationSidebar({
 
         const response = await fetch(API_ROUTES.EXPLAIN_SENTENCE, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...guestKeyHeaders('gemini') },
           body: JSON.stringify(requestData),
         });
 
         if (!response.ok) {
+          if (response.status === 401) {
+            const info = await response.json().catch(() => null);
+            if (info?.requiresGuestKey === 'gemini') {
+              promptGuestKey('gemini');
+              throw new Error('Guest mode: add your own Gemini API key to use AI explanations.');
+            }
+          }
           throw new Error(`Failed to fetch explanation: ${response.statusText}`);
         }
 

--- a/app/components/reading/GuestApiKeyModal.tsx
+++ b/app/components/reading/GuestApiKeyModal.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { COLORS } from '@/lib/constants';
+import { COLORS, DARK_COLORS } from '@/lib/constants';
 import {
   type GuestKeyKind,
   getGuestKey,
   setGuestKey,
   GUEST_KEY_REQUIRED_EVENT,
 } from '@/lib/guestKeys';
+
+interface GuestApiKeyModalProps {
+  isDarkMode?: boolean;
+}
 
 const COPY: Record<GuestKeyKind, { title: string; help: string; link: string; linkLabel: string }> = {
   gemini: {
@@ -30,7 +34,7 @@ const COPY: Record<GuestKeyKind, { title: string; help: string; link: string; li
   },
 };
 
-export default function GuestApiKeyModal() {
+export default function GuestApiKeyModal({ isDarkMode = false }: GuestApiKeyModalProps) {
   const [kind, setKind] = useState<GuestKeyKind | null>(null);
   const [value, setValue] = useState('');
 
@@ -48,6 +52,28 @@ export default function GuestApiKeyModal() {
 
   const copy = COPY[kind];
 
+  const theme = isDarkMode
+    ? {
+        card: DARK_COLORS.SURFACE,
+        title: DARK_COLORS.TEXT,
+        help: '#A0A0A5',
+        inputBg: DARK_COLORS.NEUTRAL,
+        inputBorder: 'rgba(255,255,255,0.14)',
+        cancelBg: DARK_COLORS.NEUTRAL,
+        cancelText: DARK_COLORS.TEXT,
+        primary: DARK_COLORS.PRIMARY,
+      }
+    : {
+        card: '#FFFFFF',
+        title: '#1D1D1F',
+        help: '#636366',
+        inputBg: '#F2F2F7',
+        inputBorder: 'rgba(0,0,0,0.12)',
+        cancelBg: '#F2F2F7',
+        cancelText: '#1D1D1F',
+        primary: COLORS.PRIMARY,
+      };
+
   const handleSave = () => {
     const trimmed = value.trim();
     if (!trimmed) return;
@@ -63,13 +89,13 @@ export default function GuestApiKeyModal() {
     >
       <div
         className="w-full max-w-md rounded-2xl p-6"
-        style={{ backgroundColor: '#FFFFFF', boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}
+        style={{ backgroundColor: theme.card, boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-lg font-semibold mb-2" style={{ color: '#1D1D1F' }}>
+        <h2 className="text-lg font-semibold mb-2" style={{ color: theme.title }}>
           {copy.title}
         </h2>
-        <p className="text-sm mb-4 leading-relaxed" style={{ color: '#636366' }}>
+        <p className="text-sm mb-4 leading-relaxed" style={{ color: theme.help }}>
           {copy.help}
         </p>
 
@@ -83,7 +109,7 @@ export default function GuestApiKeyModal() {
           placeholder="Paste your API key"
           autoFocus
           className="w-full rounded-xl px-3 py-2.5 text-sm mb-3"
-          style={{ border: '1px solid rgba(0,0,0,0.12)', backgroundColor: '#F2F2F7' }}
+          style={{ border: `1px solid ${theme.inputBorder}`, backgroundColor: theme.inputBg, color: theme.title }}
         />
 
         <a
@@ -91,7 +117,7 @@ export default function GuestApiKeyModal() {
           target="_blank"
           rel="noreferrer"
           className="text-sm font-medium interactive-link"
-          style={{ color: COLORS.PRIMARY }}
+          style={{ color: theme.primary }}
         >
           {copy.linkLabel}
         </a>
@@ -100,7 +126,7 @@ export default function GuestApiKeyModal() {
           <button
             onClick={() => setKind(null)}
             className="px-4 py-2 rounded-xl text-sm font-medium"
-            style={{ backgroundColor: '#F2F2F7', color: '#1D1D1F' }}
+            style={{ backgroundColor: theme.cancelBg, color: theme.cancelText }}
           >
             Cancel
           </button>
@@ -108,7 +134,7 @@ export default function GuestApiKeyModal() {
             onClick={handleSave}
             disabled={!value.trim()}
             className="px-4 py-2 rounded-xl text-sm font-medium disabled:opacity-40"
-            style={{ backgroundColor: COLORS.PRIMARY, color: '#FFFFFF' }}
+            style={{ backgroundColor: theme.primary, color: '#FFFFFF' }}
           >
             Save key
           </button>

--- a/app/components/reading/GuestApiKeyModal.tsx
+++ b/app/components/reading/GuestApiKeyModal.tsx
@@ -22,6 +22,12 @@ const COPY: Record<GuestKeyKind, { title: string; help: string; link: string; li
     link: 'https://console.cloud.google.com/apis/credentials',
     linkLabel: 'Get a Google Cloud TTS API key',
   },
+  translate: {
+    title: 'Translation uses your own key',
+    help: 'In guest mode, translation runs on your personal Google Cloud Translation API key. It is stored only in this browser and sent solely to make your request.',
+    link: 'https://console.cloud.google.com/apis/credentials',
+    linkLabel: 'Get a Google Cloud Translation API key',
+  },
 };
 
 export default function GuestApiKeyModal() {

--- a/app/components/reading/GuestApiKeyModal.tsx
+++ b/app/components/reading/GuestApiKeyModal.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { COLORS } from '@/lib/constants';
+import {
+  type GuestKeyKind,
+  getGuestKey,
+  setGuestKey,
+  GUEST_KEY_REQUIRED_EVENT,
+} from '@/lib/guestKeys';
+
+const COPY: Record<GuestKeyKind, { title: string; help: string; link: string; linkLabel: string }> = {
+  gemini: {
+    title: 'AI explanations use your own key',
+    help: 'In guest mode, AI explanations run on your personal Google Gemini API key. It is stored only in this browser and sent solely to make your request.',
+    link: 'https://aistudio.google.com/apikey',
+    linkLabel: 'Get a free Gemini API key',
+  },
+  tts: {
+    title: 'Audio uses your own key',
+    help: 'In guest mode, text-to-speech runs on your personal Google Cloud TTS API key. It is stored only in this browser and sent solely to make your request.',
+    link: 'https://console.cloud.google.com/apis/credentials',
+    linkLabel: 'Get a Google Cloud TTS API key',
+  },
+};
+
+export default function GuestApiKeyModal() {
+  const [kind, setKind] = useState<GuestKeyKind | null>(null);
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { kind: GuestKeyKind };
+      setKind(detail.kind);
+      setValue(getGuestKey(detail.kind) || '');
+    };
+    window.addEventListener(GUEST_KEY_REQUIRED_EVENT, handler);
+    return () => window.removeEventListener(GUEST_KEY_REQUIRED_EVENT, handler);
+  }, []);
+
+  if (!kind) return null;
+
+  const copy = COPY[kind];
+
+  const handleSave = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setGuestKey(kind, trimmed);
+    setKind(null);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+      onClick={() => setKind(null)}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl p-6"
+        style={{ backgroundColor: '#FFFFFF', boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-2" style={{ color: '#1D1D1F' }}>
+          {copy.title}
+        </h2>
+        <p className="text-sm mb-4 leading-relaxed" style={{ color: '#636366' }}>
+          {copy.help}
+        </p>
+
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSave();
+          }}
+          placeholder="Paste your API key"
+          autoFocus
+          className="w-full rounded-xl px-3 py-2.5 text-sm mb-3"
+          style={{ border: '1px solid rgba(0,0,0,0.12)', backgroundColor: '#F2F2F7' }}
+        />
+
+        <a
+          href={copy.link}
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm font-medium interactive-link"
+          style={{ color: COLORS.PRIMARY }}
+        >
+          {copy.linkLabel}
+        </a>
+
+        <div className="flex justify-end gap-2 mt-5">
+          <button
+            onClick={() => setKind(null)}
+            className="px-4 py-2 rounded-xl text-sm font-medium"
+            style={{ backgroundColor: '#F2F2F7', color: '#1D1D1F' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!value.trim()}
+            className="px-4 py-2 rounded-xl text-sm font-medium disabled:opacity-40"
+            style={{ backgroundColor: COLORS.PRIMARY, color: '#FFFFFF' }}
+          >
+            Save key
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/reading/ParagraphItem.tsx
+++ b/app/components/reading/ParagraphItem.tsx
@@ -8,6 +8,7 @@ import StartHereIcon from "@/app/components/icons/StartHereIcon";
 import BookImage from "@/app/components/reading/BookImage";
 import { COLORS, EXPLANATION_CONFIG } from "@/lib/constants";
 import { parseFurigana, segmentsToHTML } from "@/lib/utils/furiganaParser";
+import { guestKeyHeaders, promptGuestKey } from "@/lib/guestKeys";
 
 const IMAGE_PATTERN = /\[IMAGE:([^\]]+)\]/;
 
@@ -94,11 +95,19 @@ const ParagraphItem: React.FC<ParagraphItemProps> = ({
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...guestKeyHeaders("translate"),
         },
         body: JSON.stringify({ text }),
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          const info = await response.json().catch(() => null);
+          if (info?.requiresGuestKey === "translate") {
+            promptGuestKey("translate");
+            return;
+          }
+        }
         throw new Error("Translation failed");
       }
 

--- a/app/components/reading/ParagraphItem.tsx
+++ b/app/components/reading/ParagraphItem.tsx
@@ -8,7 +8,7 @@ import StartHereIcon from "@/app/components/icons/StartHereIcon";
 import BookImage from "@/app/components/reading/BookImage";
 import { COLORS, EXPLANATION_CONFIG } from "@/lib/constants";
 import { parseFurigana, segmentsToHTML } from "@/lib/utils/furiganaParser";
-import { guestKeyHeaders, promptGuestKey } from "@/lib/guestKeys";
+import { guestKeyHeaders, promptGuestKeyOnFailure } from "@/lib/guestKeys";
 
 const IMAGE_PATTERN = /\[IMAGE:([^\]]+)\]/;
 
@@ -101,13 +101,7 @@ const ParagraphItem: React.FC<ParagraphItemProps> = ({
       });
 
       if (!response.ok) {
-        if (response.status === 401) {
-          const info = await response.json().catch(() => null);
-          if (info?.requiresGuestKey === "translate") {
-            promptGuestKey("translate");
-            return;
-          }
-        }
+        await promptGuestKeyOnFailure("translate", response);
         throw new Error("Translation failed");
       }
 

--- a/app/components/ui/GuestModeBanner.tsx
+++ b/app/components/ui/GuestModeBanner.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { COLORS } from '@/lib/constants';
+
+interface GuestModeBannerProps {
+  message?: string;
+}
+
+export default function GuestModeBanner({ message }: GuestModeBannerProps) {
+  return (
+    <div style={{ backgroundColor: '#FFF7E6', borderBottom: '1px solid #FFE1A8' }}>
+      <div className="max-w-6xl mx-auto px-4 py-2 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm" style={{ color: '#8A6D3B' }}>
+          <span
+            className="px-2 py-0.5 rounded-md text-xs font-semibold whitespace-nowrap"
+            style={{ backgroundColor: '#FFE1A8', color: '#7A5A1E' }}
+          >
+            Guest mode
+          </span>
+          <span>
+            {message || 'You are reading a free preview. Sign in for the full library.'}
+          </span>
+        </div>
+        <Link
+          href="/login"
+          className="text-sm font-semibold whitespace-nowrap interactive-link"
+          style={{ color: COLORS.PRIMARY }}
+        >
+          Sign in
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/GuestModeBanner.tsx
+++ b/app/components/ui/GuestModeBanner.tsx
@@ -1,20 +1,39 @@
 'use client';
 
 import Link from 'next/link';
-import { COLORS } from '@/lib/constants';
+import { COLORS, DARK_COLORS } from '@/lib/constants';
 
 interface GuestModeBannerProps {
   message?: string;
+  isDarkMode?: boolean;
 }
 
-export default function GuestModeBanner({ message }: GuestModeBannerProps) {
+export default function GuestModeBanner({ message, isDarkMode = false }: GuestModeBannerProps) {
+  const theme = isDarkMode
+    ? {
+        bg: DARK_COLORS.SURFACE,
+        border: 'rgba(255,193,77,0.25)',
+        text: '#E0B872',
+        chipBg: 'rgba(255,193,77,0.18)',
+        chipText: '#F0C674',
+        link: DARK_COLORS.PRIMARY,
+      }
+    : {
+        bg: '#FFF7E6',
+        border: '#FFE1A8',
+        text: '#8A6D3B',
+        chipBg: '#FFE1A8',
+        chipText: '#7A5A1E',
+        link: COLORS.PRIMARY,
+      };
+
   return (
-    <div style={{ backgroundColor: '#FFF7E6', borderBottom: '1px solid #FFE1A8' }}>
+    <div style={{ backgroundColor: theme.bg, borderBottom: `1px solid ${theme.border}` }}>
       <div className="max-w-6xl mx-auto px-4 py-2 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-sm" style={{ color: '#8A6D3B' }}>
+        <div className="flex items-center gap-2 text-sm" style={{ color: theme.text }}>
           <span
             className="px-2 py-0.5 rounded-md text-xs font-semibold whitespace-nowrap"
-            style={{ backgroundColor: '#FFE1A8', color: '#7A5A1E' }}
+            style={{ backgroundColor: theme.chipBg, color: theme.chipText }}
           >
             Guest mode
           </span>
@@ -25,7 +44,7 @@ export default function GuestModeBanner({ message }: GuestModeBannerProps) {
         <Link
           href="/login"
           className="text-sm font-semibold whitespace-nowrap interactive-link"
-          style={{ color: COLORS.PRIMARY }}
+          style={{ color: theme.link }}
         >
           Sign in
         </Link>

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useExplanationCache';
 export * from './useBookMetadata';
 export * from './useTTS';
 export * from './useRubyRegistry';
+export * from './useGuestMode';

--- a/app/hooks/useGuestMode.ts
+++ b/app/hooks/useGuestMode.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { API_ROUTES } from '@/lib/constants';
+
+interface GuestModeState {
+  isGuest: boolean;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Reports whether the current visitor is signed in. Until the session check
+ * resolves, isGuest stays false so guest-only UI never flashes for real users.
+ */
+export function useGuestMode(): GuestModeState {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const checkSession = async () => {
+      try {
+        const res = await fetch(API_ROUTES.AUTH_SESSION);
+        const data = await res.json();
+        if (active) setIsAuthenticated(Boolean(data.authenticated));
+      } catch {
+        if (active) setIsAuthenticated(false);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    };
+
+    checkSession();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return {
+    isGuest: !isLoading && !isAuthenticated,
+    isAuthenticated,
+    isLoading,
+  };
+}

--- a/app/hooks/useGuestMode.ts
+++ b/app/hooks/useGuestMode.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { API_ROUTES } from '@/lib/constants';
+import { clearGuestKeys } from '@/lib/guestKeys';
 
 interface GuestModeState {
   isGuest: boolean;
@@ -24,9 +25,13 @@ export function useGuestMode(): GuestModeState {
       try {
         const res = await fetch(API_ROUTES.AUTH_SESSION);
         const data = await res.json();
-        // Fail closed: only show guest UI when the server explicitly says so, so
-        // a failed/non-JSON session check never degrades the signed-in owner's chrome.
-        if (active) setIsGuest(data.authenticated === false);
+        // Only show guest UI when the server explicitly reports no session; on a
+        // failed/non-JSON check assume signed-in so the owner's chrome is never
+        // degraded. Clear any stale guest keys once a session is confirmed.
+        if (active) {
+          setIsGuest(data.authenticated === false);
+          if (data.authenticated === true) clearGuestKeys();
+        }
       } catch {
         if (active) setIsGuest(false);
       } finally {

--- a/app/hooks/useGuestMode.ts
+++ b/app/hooks/useGuestMode.ts
@@ -14,7 +14,7 @@ interface GuestModeState {
  * resolves, isGuest stays false so guest-only UI never flashes for real users.
  */
 export function useGuestMode(): GuestModeState {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isGuest, setIsGuest] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -24,9 +24,11 @@ export function useGuestMode(): GuestModeState {
       try {
         const res = await fetch(API_ROUTES.AUTH_SESSION);
         const data = await res.json();
-        if (active) setIsAuthenticated(Boolean(data.authenticated));
+        // Fail closed: only show guest UI when the server explicitly says so, so
+        // a failed/non-JSON session check never degrades the signed-in owner's chrome.
+        if (active) setIsGuest(data.authenticated === false);
       } catch {
-        if (active) setIsAuthenticated(false);
+        if (active) setIsGuest(false);
       } finally {
         if (active) setIsLoading(false);
       }
@@ -39,8 +41,8 @@ export function useGuestMode(): GuestModeState {
   }, []);
 
   return {
-    isGuest: !isLoading && !isAuthenticated,
-    isAuthenticated,
+    isGuest,
+    isAuthenticated: !isLoading && !isGuest,
     isLoading,
   };
 }

--- a/app/hooks/useTTS.ts
+++ b/app/hooks/useTTS.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { API_ROUTES, STORAGE_KEYS, TTS_CONFIG, type TTSVoiceGender } from '@/lib/constants';
 import type { TTSRequest, TTSResponse } from '@/lib/types';
 import { cleanTextForTTS } from '@/lib/utils/ttsTextCleaner';
+import { guestKeyHeaders, promptGuestKey } from '@/lib/guestKeys';
 
 interface UseTTSOptions {
   onPlayStart?: () => void;
@@ -145,11 +146,19 @@ export function useTTS(options: UseTTSOptions = {}): UseTTSReturn {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...guestKeyHeaders('tts'),
         },
         body: JSON.stringify(requestData),
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          const info = await response.json().catch(() => null);
+          if (info?.requiresGuestKey === 'tts') {
+            promptGuestKey('tts');
+            throw new Error('Add your Google TTS API key to play audio in guest mode.');
+          }
+        }
         throw new Error(`TTS生成に失敗しました: ${response.statusText}`);
       }
 

--- a/app/hooks/useTTS.ts
+++ b/app/hooks/useTTS.ts
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { API_ROUTES, STORAGE_KEYS, TTS_CONFIG, type TTSVoiceGender } from '@/lib/constants';
 import type { TTSRequest, TTSResponse } from '@/lib/types';
 import { cleanTextForTTS } from '@/lib/utils/ttsTextCleaner';
-import { guestKeyHeaders, promptGuestKey } from '@/lib/guestKeys';
+import { guestKeyHeaders, promptGuestKeyOnFailure } from '@/lib/guestKeys';
 
 interface UseTTSOptions {
   onPlayStart?: () => void;
@@ -152,14 +152,12 @@ export function useTTS(options: UseTTSOptions = {}): UseTTSReturn {
       });
 
       if (!response.ok) {
-        if (response.status === 401) {
-          const info = await response.json().catch(() => null);
-          if (info?.requiresGuestKey === 'tts') {
-            promptGuestKey('tts');
-            throw new Error('Add your Google TTS API key to play audio in guest mode.');
-          }
-        }
-        throw new Error(`TTS生成に失敗しました: ${response.statusText}`);
+        const prompted = await promptGuestKeyOnFailure('tts', response);
+        throw new Error(
+          prompted
+            ? 'Add or update your Google TTS API key to play audio.'
+            : `TTS生成に失敗しました: ${response.statusText}`
+        );
       }
 
       const data: TTSResponse = await response.json();

--- a/app/library/components/BookCard.tsx
+++ b/app/library/components/BookCard.tsx
@@ -9,6 +9,7 @@ interface BookCardProps {
   totalCharacters?: number;
   directoryTag: string;
   bookmarkPage?: number | null;
+  isPreview?: boolean;
 }
 
 export default function BookCard({
@@ -18,6 +19,7 @@ export default function BookCard({
   totalCharacters,
   directoryTag,
   bookmarkPage,
+  isPreview,
 }: BookCardProps) {
   const displayName = fileName
     .replace(/-rephrase-furigana$/, '')
@@ -39,7 +41,7 @@ export default function BookCard({
         }}
       >
         <div className="aspect-[3/4] flex flex-col">
-          <div className="px-3 pt-3">
+          <div className="px-3 pt-3 flex items-center justify-between gap-2">
             <span
               className="inline-block px-2 py-0.5 rounded-md text-xs font-medium"
               style={{
@@ -49,6 +51,14 @@ export default function BookCard({
             >
               {directoryTag}
             </span>
+            {isPreview && (
+              <span
+                className="inline-block px-2 py-0.5 rounded-md text-xs font-semibold"
+                style={{ backgroundColor: '#FFE1A8', color: '#7A5A1E' }}
+              >
+                Preview
+              </span>
+            )}
           </div>
 
           <div className="flex-1 flex items-center justify-center px-4">

--- a/app/library/components/LibraryGrid.tsx
+++ b/app/library/components/LibraryGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useMemo } from 'react';
 import { API_ROUTES } from '@/lib/constants';
+import { useGuestMode } from '@/app/hooks/useGuestMode';
 import BookCard from './BookCard';
 
 interface FileListResponse {
@@ -55,6 +56,7 @@ export default function LibraryGrid() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sortMode, setSortMode] = useState<SortMode>('last-read');
+  const { isGuest } = useGuestMode();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -208,6 +210,7 @@ export default function LibraryGrid() {
             totalCharacters={book.totalCharacters}
             directoryTag={formatDirectoryTag(book.directory)}
             bookmarkPage={book.bookmarkPage}
+            isPreview={isGuest}
           />
         ))}
       </div>

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -33,7 +33,7 @@ export default function LibraryPage() {
           <nav className={`items-center gap-1 pt-1 ${isGuest ? 'hidden' : 'flex'}`}>
             <button
               onClick={() => setShowSync(true)}
-              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"
+              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5 cursor-pointer"
               style={{ color: COLORS.PRIMARY }}
               title="Database sync"
             >
@@ -43,7 +43,7 @@ export default function LibraryPage() {
             </button>
             <Link
               href="/text-input-ai"
-              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"
+              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5 cursor-pointer"
               style={{ color: COLORS.PRIMARY }}
               title="Add new text"
             >
@@ -53,7 +53,7 @@ export default function LibraryPage() {
             </Link>
             <Link
               href="/visual-novel"
-              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"
+              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5 cursor-pointer"
               style={{ color: COLORS.PRIMARY }}
               title="Visual Novel mode"
             >
@@ -66,7 +66,7 @@ export default function LibraryPage() {
                 await fetch(API_ROUTES.AUTH_LOGOUT, { method: 'POST' });
                 window.location.href = '/login';
               }}
-              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"
+              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5 cursor-pointer"
               style={{ color: COLORS.SECONDARY }}
               title="Sign out"
             >

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -2,18 +2,25 @@
 
 import { useState } from 'react';
 import { COLORS } from '@/lib/constants';
+import { useGuestMode } from '@/app/hooks/useGuestMode';
+import GuestModeBanner from '@/app/components/ui/GuestModeBanner';
 import LibraryGrid from './components/LibraryGrid';
 import DbSyncModal from './components/DbSyncModal';
 import Link from 'next/link';
 
 export default function LibraryPage() {
   const [showSync, setShowSync] = useState(false);
+  const { isGuest } = useGuestMode();
 
   return (
     <div
       className="min-h-screen"
       style={{ backgroundColor: '#F2F2F7' }}
     >
+      {isGuest && (
+        <GuestModeBanner message="A few books are available as a free preview. Sign in for the full library." />
+      )}
+
       <div className="max-w-6xl mx-auto px-5 pt-12 pb-8">
         <div className="flex items-start justify-between mb-8">
           <h1
@@ -23,7 +30,7 @@ export default function LibraryPage() {
             Library
           </h1>
 
-          <nav className="flex items-center gap-1 pt-1">
+          <nav className={`items-center gap-1 pt-1 ${isGuest ? 'hidden' : 'flex'}`}>
             <button
               onClick={() => setShowSync(true)}
               className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { COLORS } from '@/lib/constants';
+import { COLORS, API_ROUTES } from '@/lib/constants';
 import { useGuestMode } from '@/app/hooks/useGuestMode';
 import GuestModeBanner from '@/app/components/ui/GuestModeBanner';
 import LibraryGrid from './components/LibraryGrid';
@@ -61,6 +61,19 @@ export default function LibraryPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
             </Link>
+            <button
+              onClick={async () => {
+                await fetch(API_ROUTES.AUTH_LOGOUT, { method: 'POST' });
+                window.location.href = '/login';
+              }}
+              className="p-2.5 rounded-xl transition-colors duration-200 hover:bg-black/5"
+              style={{ color: COLORS.SECONDARY }}
+              title="Sign out"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+            </button>
           </nav>
         </div>
 

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -20,6 +20,8 @@ import ReadingContent from './components/ReadingContent';
 import ReaderHeader from './components/ReaderHeader';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 import { useBookMetadata } from '@/app/hooks/useBookMetadata';
+import { useGuestMode } from '@/app/hooks/useGuestMode';
+import GuestModeBanner from '@/app/components/ui/GuestModeBanner';
 import { stripFurigana } from '@/lib/utils/furiganaParser';
 import { buildPlayableUnits } from '@/lib/utils/buildPlayableUnits';
 import { useAudioBook } from '@/app/hooks/useAudioBook';
@@ -42,6 +44,11 @@ const FloatingStickyNotes = dynamic(
 
 const AudioPlayerBar = dynamic(
   () => import('./components/AudioPlayerBar'),
+  { ssr: false }
+);
+
+const GuestApiKeyModal = dynamic(
+  () => import('@/app/components/reading/GuestApiKeyModal'),
   { ssr: false }
 );
 
@@ -100,6 +107,7 @@ function ReaderContent({
   const [copyRangeFeedback, setCopyRangeFeedback] = useState(false);
 
   const { imageMap } = useBookMetadata(fileNameParam, directoryParam);
+  const { isGuest } = useGuestMode();
 
   const fullFilePath = useMemo(() => {
     if (directoryParam && fileNameParam) {
@@ -570,6 +578,10 @@ function ReaderContent({
       className="min-h-screen transition-colors duration-300"
       style={{ backgroundColor: theme.bg, color: theme.text }}
     >
+      {isGuest && (
+        <GuestModeBanner message="Preview only. Sign in to read the full book and use your saved bookmarks." />
+      )}
+
       <ProgressBar progress={progress} />
 
       <ReaderHeader
@@ -647,6 +659,27 @@ function ReaderContent({
               }}
             >
               Next
+            </button>
+          </div>
+        )}
+
+        {isGuest && (
+          <div
+            className="mt-10 rounded-2xl p-6 text-center"
+            style={{ backgroundColor: theme.surface, border: '1px solid rgba(0,0,0,0.06)' }}
+          >
+            <p className="text-base font-semibold mb-1" style={{ color: theme.text }}>
+              End of preview
+            </p>
+            <p className="text-sm mb-4" style={{ color: '#8E8E93' }}>
+              You are reading a free sample. Sign in to read the full book.
+            </p>
+            <button
+              onClick={() => router.push('/login')}
+              className="px-5 py-2.5 rounded-xl text-sm font-medium"
+              style={{ backgroundColor: COLORS.PRIMARY, color: '#FFFFFF' }}
+            >
+              Sign in
             </button>
           </div>
         )}
@@ -734,6 +767,8 @@ function ReaderContent({
           onClose={() => handleAudiobookChange(false)}
         />
       )}
+
+      {isGuest && <GuestApiKeyModal />}
     </div>
   );
 }

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -579,7 +579,10 @@ function ReaderContent({
       style={{ backgroundColor: theme.bg, color: theme.text }}
     >
       {isGuest && (
-        <GuestModeBanner message="Preview only. Sign in to read the full book and use your saved bookmarks." />
+        <GuestModeBanner
+          isDarkMode={isDarkMode}
+          message="Preview only. Sign in to read the full book and use your saved bookmarks."
+        />
       )}
 
       <ProgressBar progress={progress} />
@@ -768,7 +771,7 @@ function ReaderContent({
         />
       )}
 
-      {isGuest && <GuestApiKeyModal />}
+      <GuestApiKeyModal isDarkMode={isDarkMode} />
     </div>
   );
 }

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -2,7 +2,11 @@ import { GoogleGenAI } from "@google/genai";
 
 let aiClient: GoogleGenAI | null = null;
 
-export function getAIClient(): GoogleGenAI {
+export function getAIClient(apiKey?: string): GoogleGenAI {
+  // Guests supply their own key per request; never cache or reuse it.
+  if (apiKey) {
+    return new GoogleGenAI({ apiKey });
+  }
   if (!aiClient) {
     aiClient = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
   }

--- a/lib/auth/apiSession.ts
+++ b/lib/auth/apiSession.ts
@@ -1,0 +1,14 @@
+import { cookies } from 'next/headers';
+import { verifySession } from './session';
+
+/**
+ * Reads the `session` cookie inside a route handler and reports whether it is a
+ * valid signed-in session. Kept separate from session.ts (which the Edge
+ * middleware imports) so next/headers never enters the middleware bundle.
+ */
+export async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('session')?.value;
+  if (!token) return false;
+  return verifySession(token);
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -88,6 +88,13 @@ export const API_ROUTES = {
   DB_SYNC: '/api/db-sync',
 } as const;
 
+// Guest mode passes the reader's own API key to paid endpoints via these headers.
+// The key is stored only in the browser and never falls back to the owner's key.
+export const GUEST_KEY_HEADERS = {
+  GEMINI: 'x-guest-gemini-key',
+  TTS: 'x-guest-tts-key',
+} as const;
+
 // ページルート
 export const PAGE_ROUTES = {
   HOME: '/',
@@ -195,6 +202,9 @@ export const STORAGE_KEYS = {
   // オーディオブック設定
   AUDIOBOOK_ENABLED: 'audiobook_enabled',
   AUDIOBOOK_CONTENT_MODE: 'audiobook_content_mode',
+  // Guest mode (bring-your-own API keys, stored only in the browser)
+  GUEST_GEMINI_KEY: 'guest_gemini_api_key',
+  GUEST_TTS_KEY: 'guest_google_tts_api_key',
 } as const;
 
 // TTS（Text-to-Speech）設定

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -93,6 +93,7 @@ export const API_ROUTES = {
 export const GUEST_KEY_HEADERS = {
   GEMINI: 'x-guest-gemini-key',
   TTS: 'x-guest-tts-key',
+  TRANSLATE: 'x-guest-translate-key',
 } as const;
 
 // ページルート
@@ -205,6 +206,7 @@ export const STORAGE_KEYS = {
   // Guest mode (bring-your-own API keys, stored only in the browser)
   GUEST_GEMINI_KEY: 'guest_gemini_api_key',
   GUEST_TTS_KEY: 'guest_google_tts_api_key',
+  GUEST_TRANSLATE_KEY: 'guest_google_translate_key',
 } as const;
 
 // TTS（Text-to-Speech）設定

--- a/lib/guestKeys.ts
+++ b/lib/guestKeys.ts
@@ -7,7 +7,7 @@ import { STORAGE_KEYS, GUEST_KEY_HEADERS } from '@/lib/constants';
  * listens for it and, once saved, fires GUEST_KEY_UPDATED_EVENT so the original
  * action can retry.
  */
-export type GuestKeyKind = 'gemini' | 'tts';
+export type GuestKeyKind = 'gemini' | 'tts' | 'translate';
 
 export const GUEST_KEY_REQUIRED_EVENT = 'guestKeyRequired';
 export const GUEST_KEY_UPDATED_EVENT = 'guestKeyUpdated';
@@ -15,11 +15,13 @@ export const GUEST_KEY_UPDATED_EVENT = 'guestKeyUpdated';
 const STORAGE_KEY_BY_KIND: Record<GuestKeyKind, string> = {
   gemini: STORAGE_KEYS.GUEST_GEMINI_KEY,
   tts: STORAGE_KEYS.GUEST_TTS_KEY,
+  translate: STORAGE_KEYS.GUEST_TRANSLATE_KEY,
 };
 
 const HEADER_BY_KIND: Record<GuestKeyKind, string> = {
   gemini: GUEST_KEY_HEADERS.GEMINI,
   tts: GUEST_KEY_HEADERS.TTS,
+  translate: GUEST_KEY_HEADERS.TRANSLATE,
 };
 
 export function getGuestKey(kind: GuestKeyKind): string | null {

--- a/lib/guestKeys.ts
+++ b/lib/guestKeys.ts
@@ -1,0 +1,44 @@
+import { STORAGE_KEYS, GUEST_KEY_HEADERS } from '@/lib/constants';
+
+/**
+ * Guest bring-your-own API keys. Keys live only in the browser's localStorage
+ * and are attached to paid requests via headers. Call sites dispatch
+ * GUEST_KEY_REQUIRED_EVENT when the server reports a missing key; the modal host
+ * listens for it and, once saved, fires GUEST_KEY_UPDATED_EVENT so the original
+ * action can retry.
+ */
+export type GuestKeyKind = 'gemini' | 'tts';
+
+export const GUEST_KEY_REQUIRED_EVENT = 'guestKeyRequired';
+export const GUEST_KEY_UPDATED_EVENT = 'guestKeyUpdated';
+
+const STORAGE_KEY_BY_KIND: Record<GuestKeyKind, string> = {
+  gemini: STORAGE_KEYS.GUEST_GEMINI_KEY,
+  tts: STORAGE_KEYS.GUEST_TTS_KEY,
+};
+
+const HEADER_BY_KIND: Record<GuestKeyKind, string> = {
+  gemini: GUEST_KEY_HEADERS.GEMINI,
+  tts: GUEST_KEY_HEADERS.TTS,
+};
+
+export function getGuestKey(kind: GuestKeyKind): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(STORAGE_KEY_BY_KIND[kind]);
+}
+
+export function setGuestKey(kind: GuestKeyKind, value: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY_BY_KIND[kind], value);
+  window.dispatchEvent(new CustomEvent(GUEST_KEY_UPDATED_EVENT, { detail: { kind } }));
+}
+
+export function guestKeyHeaders(kind: GuestKeyKind): Record<string, string> {
+  const key = getGuestKey(kind);
+  return key ? { [HEADER_BY_KIND[kind]]: key } : {};
+}
+
+export function promptGuestKey(kind: GuestKeyKind): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(GUEST_KEY_REQUIRED_EVENT, { detail: { kind } }));
+}

--- a/lib/guestKeys.ts
+++ b/lib/guestKeys.ts
@@ -2,10 +2,11 @@ import { STORAGE_KEYS, GUEST_KEY_HEADERS } from '@/lib/constants';
 
 /**
  * Guest bring-your-own API keys. Keys live only in the browser's localStorage
- * and are attached to paid requests via headers. Call sites dispatch
- * GUEST_KEY_REQUIRED_EVENT when the server reports a missing key; the modal host
- * listens for it and, once saved, fires GUEST_KEY_UPDATED_EVENT so the original
- * action can retry.
+ * and are attached to paid requests via headers. When a paid request fails,
+ * call sites use promptGuestKeyOnFailure to open the key modal (GUEST_KEY_REQUIRED_EVENT) --
+ * whether the key was missing or a stored key was rejected. After a key is saved,
+ * GUEST_KEY_UPDATED_EVENT fires; AI explanations re-run automatically, other
+ * actions resume on the next interaction.
  */
 export type GuestKeyKind = 'gemini' | 'tts' | 'translate';
 
@@ -43,4 +44,29 @@ export function guestKeyHeaders(kind: GuestKeyKind): Record<string, string> {
 export function promptGuestKey(kind: GuestKeyKind): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent(GUEST_KEY_REQUIRED_EVENT, { detail: { kind } }));
+}
+
+/**
+ * Handle a failed paid-endpoint response for a guest by opening the key modal:
+ * either the server reported a missing key (401 requiresGuestKey), or a stored
+ * key was rejected (any other failure while a key is set). Signed-in users have
+ * no stored guest key, so this never fires for them. Returns true if it prompted.
+ */
+export async function promptGuestKeyOnFailure(
+  kind: GuestKeyKind,
+  response: Response
+): Promise<boolean> {
+  if (response.status === 401) {
+    const info = await response.json().catch(() => null);
+    if (info?.requiresGuestKey === kind) {
+      promptGuestKey(kind);
+      return true;
+    }
+    return false;
+  }
+  if (getGuestKey(kind)) {
+    promptGuestKey(kind);
+    return true;
+  }
+  return false;
 }

--- a/lib/guestKeys.ts
+++ b/lib/guestKeys.ts
@@ -46,27 +46,37 @@ export function promptGuestKey(kind: GuestKeyKind): void {
   window.dispatchEvent(new CustomEvent(GUEST_KEY_REQUIRED_EVENT, { detail: { kind } }));
 }
 
+// Clears every stored guest key. Called once a real session is detected so a
+// signed-in owner never carries a stale guest key from an earlier guest session.
+export function clearGuestKeys(): void {
+  if (typeof window === 'undefined') return;
+  (Object.keys(STORAGE_KEY_BY_KIND) as GuestKeyKind[]).forEach((kind) => {
+    localStorage.removeItem(STORAGE_KEY_BY_KIND[kind]);
+  });
+}
+
+async function serverRequestedGuestKey(
+  kind: GuestKeyKind,
+  response: Response
+): Promise<boolean> {
+  if (response.status !== 401) return false;
+  const info = await response.json().catch(() => null);
+  return info?.requiresGuestKey === kind;
+}
+
 /**
- * Handle a failed paid-endpoint response for a guest by opening the key modal:
- * either the server reported a missing key (401 requiresGuestKey), or a stored
- * key was rejected (any other failure while a key is set). Signed-in users have
- * no stored guest key, so this never fires for them. Returns true if it prompted.
+ * Handle a failed paid-endpoint response by opening the key modal when either
+ * the server reported a missing key (401 requiresGuestKey) or a stored key was
+ * rejected (any failure while a key is set). Guest keys are cleared once a
+ * session is detected, so in practice this only affects guests. Returns true if
+ * it prompted.
  */
 export async function promptGuestKeyOnFailure(
   kind: GuestKeyKind,
   response: Response
 ): Promise<boolean> {
-  if (response.status === 401) {
-    const info = await response.json().catch(() => null);
-    if (info?.requiresGuestKey === kind) {
-      promptGuestKey(kind);
-      return true;
-    }
-    return false;
-  }
-  if (getGuestKey(kind)) {
-    promptGuestKey(kind);
-    return true;
-  }
-  return false;
+  const needsKey = await serverRequestedGuestKey(kind, response);
+  if (!needsKey && !getGuestKey(kind)) return false;
+  promptGuestKey(kind);
+  return true;
 }

--- a/lib/publicBooks.ts
+++ b/lib/publicBooks.ts
@@ -14,7 +14,7 @@ export interface PublicBook {
 
 export const DEFAULT_PREVIEW_PAGES = 5;
 
-export const PUBLIC_BOOKS: PublicBook[] = [
+export const PUBLIC_BOOKS: readonly PublicBook[] = [
   {
     directory: 'bookv2-furigana/アドラー心理学を職場に取り入れてみた アドラー心理学を実践で学ぶ',
     fileName: 'アドラー心理学を職場に取り入れてみた アドラー心理学を実践で学ぶ-rephrase-furigana',

--- a/lib/publicBooks.ts
+++ b/lib/publicBooks.ts
@@ -1,0 +1,65 @@
+/**
+ * Public (guest-accessible) book allowlist.
+ *
+ * These few books are readable without signing in, capped to a short page
+ * preview to respect copyright. This is the single source of truth consulted
+ * by the page-route middleware and by the content API routes.
+ */
+
+export interface PublicBook {
+  directory: string;
+  fileName: string;
+  maxPreviewPages: number;
+}
+
+export const DEFAULT_PREVIEW_PAGES = 5;
+
+export const PUBLIC_BOOKS: PublicBook[] = [
+  {
+    directory: 'bookv2-furigana/アドラー心理学を職場に取り入れてみた アドラー心理学を実践で学ぶ',
+    fileName: 'アドラー心理学を職場に取り入れてみた アドラー心理学を実践で学ぶ-rephrase-furigana',
+    maxPreviewPages: DEFAULT_PREVIEW_PAGES,
+  },
+  {
+    directory: 'bookv2-furigana/幼女戦記 1 Deus lo vult',
+    fileName: '幼女戦記 1 Deus lo vult-rephrase-furigana',
+    maxPreviewPages: DEFAULT_PREVIEW_PAGES,
+  },
+  {
+    directory: 'bookv2-furigana/いま悩む人への「禅語」～あなたに必要なすべてがあります～',
+    fileName: 'いま悩む人への「禅語」～あなたに必要なすべてがあります～-rephrase-furigana',
+    maxPreviewPages: DEFAULT_PREVIEW_PAGES,
+  },
+];
+
+function publicBookPath(book: PublicBook): string {
+  return `${book.directory}/${book.fileName}`;
+}
+
+export function findPublicBook(
+  directory: string | null | undefined,
+  fileName: string | null | undefined
+): PublicBook | null {
+  if (!directory || !fileName) return null;
+  return (
+    PUBLIC_BOOKS.find(
+      (book) => book.directory === directory && book.fileName === fileName
+    ) || null
+  );
+}
+
+/**
+ * Match a book by its combined "directory/fileName" path. The reader fetches
+ * content with the two parts joined, so API routes resolve the book this way.
+ */
+export function findPublicBookByPath(
+  fullPath: string | null | undefined
+): PublicBook | null {
+  if (!fullPath) return null;
+  return PUBLIC_BOOKS.find((book) => publicBookPath(book) === fullPath) || null;
+}
+
+export function isPublicDirectory(directory: string | null | undefined): boolean {
+  if (!directory) return false;
+  return PUBLIC_BOOKS.some((book) => book.directory === directory);
+}

--- a/lib/utils/truncatePreview.ts
+++ b/lib/utils/truncatePreview.ts
@@ -1,0 +1,47 @@
+import { parseMarkdown } from '@/lib/utils/markdownParser';
+import { PAGINATION_CONFIG, READER_CONFIG } from '@/lib/constants';
+import type { ParsedItem } from '@/lib/types';
+
+/**
+ * Trims book content to the first N reader pages for the guest preview.
+ *
+ * A "page" is a client-side slice of PAGINATION_CONFIG.ITEMS_PER_PAGE reader
+ * units, so the cap is expressed in units. The reader re-derives units from the
+ * text via buildPlayableUnits, so the returned text must parse back to the same
+ * unit boundaries: rephrase content is parsed and re-serialized in canonical
+ * `<head` / `>>sub` form, plain/furigana content is truncated by paragraph.
+ * The rest of the book is never included in the output.
+ */
+function isRephraseContent(content: string): boolean {
+  return content.includes('>>') && content.includes('<');
+}
+
+function serializeRephraseItems(items: ParsedItem[]): string {
+  return items
+    .map((item) =>
+      [`<${item.head}`, ...item.subItems.map((sub) => `>>${sub}`)].join('\n')
+    )
+    .join('\n\n');
+}
+
+export function truncateToPreviewPages(
+  content: string,
+  maxPages: number,
+  itemsPerPage: number = PAGINATION_CONFIG.ITEMS_PER_PAGE
+): string {
+  const maxUnits = maxPages * itemsPerPage;
+
+  if (isRephraseContent(content)) {
+    const items = parseMarkdown(content);
+    if (items.length <= maxUnits) return content;
+    return serializeRephraseItems(items.slice(0, maxUnits));
+  }
+
+  const paragraphs = content
+    .split(READER_CONFIG.PARAGRAPH_SPLIT_PATTERN)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+
+  if (paragraphs.length <= maxUnits) return content;
+  return paragraphs.slice(0, maxUnits).join('\n\n');
+}

--- a/lib/utils/truncatePreview.ts
+++ b/lib/utils/truncatePreview.ts
@@ -2,16 +2,6 @@ import { parseMarkdown } from '@/lib/utils/markdownParser';
 import { PAGINATION_CONFIG, READER_CONFIG } from '@/lib/constants';
 import type { ParsedItem } from '@/lib/types';
 
-/**
- * Trims book content to the first N reader pages for the guest preview.
- *
- * A "page" is a client-side slice of PAGINATION_CONFIG.ITEMS_PER_PAGE reader
- * units, so the cap is expressed in units. The reader re-derives units from the
- * text via buildPlayableUnits, so the returned text must parse back to the same
- * unit boundaries: rephrase content is parsed and re-serialized in canonical
- * `<head` / `>>sub` form, plain/furigana content is truncated by paragraph.
- * The rest of the book is never included in the output.
- */
 function isRephraseContent(content: string): boolean {
   return content.includes('>>') && content.includes('<');
 }
@@ -24,12 +14,24 @@ function serializeRephraseItems(items: ParsedItem[]): string {
     .join('\n\n');
 }
 
+/**
+ * Trims book content to the first N reader pages for the guest preview.
+ *
+ * A "page" is a client-side slice of PAGINATION_CONFIG.ITEMS_PER_PAGE reader
+ * units, so the cap is expressed in units. The reader re-derives units from the
+ * text via buildPlayableUnits, so the returned text must parse back to the same
+ * unit boundaries: rephrase content is parsed and re-serialized in canonical
+ * `<head` / `>>sub` form, plain/furigana content is truncated by paragraph.
+ * The rest of the book is never included in the output.
+ */
 export function truncateToPreviewPages(
   content: string,
   maxPages: number,
   itemsPerPage: number = PAGINATION_CONFIG.ITEMS_PER_PAGE
 ): string {
-  const maxUnits = maxPages * itemsPerPage;
+  // Clamp defensively: a mis-edited (zero/negative/non-integer) cap must never
+  // widen the preview via slice(0, negative) or a fractional boundary.
+  const maxUnits = Math.max(0, Math.floor(maxPages)) * itemsPerPage;
 
   if (isRephraseContent(content)) {
     const items = parseMarkdown(content);

--- a/lib/utils/ttsCache.ts
+++ b/lib/utils/ttsCache.ts
@@ -1,6 +1,7 @@
 import { API_ROUTES, type TTSVoiceGender } from '@/lib/constants';
 import type { TTSRequest, TTSResponse } from '@/lib/types';
 import { cleanTextForTTS } from '@/lib/utils/ttsTextCleaner';
+import { guestKeyHeaders, promptGuestKeyOnFailure } from '@/lib/guestKeys';
 
 interface FetchTTSParams {
   text: string;
@@ -31,10 +32,11 @@ async function synthesize({ text, speed, voiceGender }: FetchTTSParams): Promise
   const body: TTSRequest = { text, speed, voiceGender };
   const response = await fetch(API_ROUTES.TTS, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...guestKeyHeaders('tts') },
     body: JSON.stringify(body),
   });
   if (!response.ok) {
+    await promptGuestKeyOnFailure('tts', response);
     throw new Error(`TTS request failed: ${response.status}`);
   }
   const data: TTSResponse = await response.json();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,27 +1,41 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { verifySession } from '@/lib/auth/session';
+import { findPublicBook } from '@/lib/publicBooks';
+
+// Pages a signed-out guest may reach: the public library and the reader, the
+// latter only for an allowlisted book (checked against the query params).
+function isGuestAllowed(request: NextRequest): boolean {
+  const path = request.nextUrl.pathname;
+
+  if (path === '/' || path === '/library') {
+    return true;
+  }
+
+  if (path === '/read') {
+    const directory = request.nextUrl.searchParams.get('directory');
+    const fileName = request.nextUrl.searchParams.get('fileName');
+    return findPublicBook(directory, fileName) !== null;
+  }
+
+  return false;
+}
 
 export async function middleware(request: NextRequest) {
-  // Public routes (no auth needed)
-  const publicPaths = ['/login'];
-  const isPublicPath = publicPaths.some((path) =>
-    request.nextUrl.pathname.startsWith(path)
-  );
-
-  if (isPublicPath) {
+  if (request.nextUrl.pathname.startsWith('/login')) {
     return NextResponse.next();
   }
 
-  // Check session cookie
   const sessionCookie = request.cookies.get('session');
-
-  if (!sessionCookie || !(await verifySession(sessionCookie.value))) {
-    // Redirect to login if not authenticated
-    return NextResponse.redirect(new URL('/login', request.url));
+  if (sessionCookie && (await verifySession(sessionCookie.value))) {
+    return NextResponse.next();
   }
 
-  return NextResponse.next();
+  if (isGuestAllowed(request)) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.redirect(new URL('/login', request.url));
 }
 
 // Protect all routes except public ones

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,20 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { verifySession } from '@/lib/auth/session';
-import { findPublicBook } from '@/lib/publicBooks';
+import { findPublicBook, PUBLIC_BOOKS } from '@/lib/publicBooks';
 
-// Pages a signed-out guest may reach: the public library and the reader, the
-// latter only for an allowlisted book (checked against the query params).
+// What a signed-out guest may reach: the home redirect ('/') and public library,
+// the reader ('/read') for an allowlisted book (checked against the query params),
+// and an allowlisted book's own static assets (e.g. the metadata JSON that the
+// reader fetches to resolve inline illustrations).
+function decodePath(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    return pathname;
+  }
+}
+
 function isGuestAllowed(request: NextRequest): boolean {
   const path = request.nextUrl.pathname;
 
@@ -18,7 +28,9 @@ function isGuestAllowed(request: NextRequest): boolean {
     return findPublicBook(directory, fileName) !== null;
   }
 
-  return false;
+  // Static assets are requested under the book's path (which may be percent-encoded).
+  const decodedPath = decodePath(path);
+  return PUBLIC_BOOKS.some((book) => decodedPath.startsWith(`/${book.directory}/`));
 }
 
 export async function middleware(request: NextRequest) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,8 +28,12 @@ function isGuestAllowed(request: NextRequest): boolean {
     return findPublicBook(directory, fileName) !== null;
   }
 
-  // Static assets are requested under the book's path (which may be percent-encoded).
+  // Guests may fetch only an allowlisted book's metadata JSON (used to resolve
+  // inline illustrations; the path may be percent-encoded). Restricting to .json
+  // keeps the full-text .txt sibling from riding along and bypassing the preview
+  // cap; images are already excluded from the matcher, so they still render.
   const decodedPath = decodePath(path);
+  if (!decodedPath.endsWith('.json')) return false;
   return PUBLIC_BOOKS.some((book) => decodedPath.startsWith(`/${book.directory}/`));
 }
 


### PR DESCRIPTION
## What & why

Currently the app requires sign-in for everything. This lets signed-out **guests** read a small, curated set of books as a **copyright-safe preview**, while keeping the full library and owner data behind login.

Public (guest-readable) books — first **5 pages** each (~250 sentences), enforced **server-side**:
1. アドラー心理学を職場に取り入れてみた アドラー心理学を実践で学ぶ
2. 幼女戦記 1 Deus lo vult
3. いま悩む人への「禅語」～あなたに必要なすべてがあります～

The allowlist lives in `lib/publicBooks.ts` (single source of truth for both middleware and API routes). Change the list or per-book `maxPreviewPages` there.

## How it works

- **Server-enforced preview** — `read-public-txt` / `text-entries` (GET) truncate to the first N pages for guests via `lib/utils/truncatePreview.ts` (parses to reader units, re-serializes a canonical prefix that round-trips to exactly N pages). The rest of the book is never sent — not just hidden.
- **Middleware** — guests may reach `/`, `/library`, and `/read` **only** for an allowlisted book (checked against the query params). Everything else still redirects to `/login`.
- **Guest library** — `list-text-files` / `library-progress` return only the 3 books for guests, with no owner bookmark/progress leaked.
- **Bring-your-own-key** — AI explanation (Gemini), TTS (Google), and translation (Google) work for guests **with their own API key**, stored only in the browser (localStorage) and sent per-request. The server never falls back to the owner's key for a guest. First use prompts a modal (`GuestApiKeyModal`).
- **Guest UI** — a persistent "Guest mode — preview" banner + Sign in, a Preview badge on library cards, an end-of-preview CTA, and owner-only nav hidden.
- **Writes rejected for guests** — `write-bookmark`, `vocabulary` (POST), `ruby-registry` (POST/DELETE) return 401 so anonymous users can't touch owner data.
- **Owner-only endpoints closed to guests** — `gemini-api`, `write-public-txt`, `write-public-txt-ai`, `text-entries` DELETE, and non-public `ruby-registry` GET/POST/DELETE now require a session. `text-entries` **PUT is left open** so the EPUB pipeline (which PUTs without a session) keeps working — see follow-ups.

Signed-in behavior is unchanged everywhere (every gate is `authenticated → original behavior`).

## Review

A multi-agent adversarial review of the diff ran before this PR (parallel reviewers for security bypass / signed-in regression / client bugs / edge cases, each finding independently verified). It surfaced 7 real issues, all fixed here:
- **[high]** guest could `DELETE`/overwrite book content via `text-entries` — DELETE now gated (PUT below).
- **[med]** audiobook/continuous TTS went through a second call site (`ttsCache.ts`) that didn't send the guest key — now wired.
- **[low]** `ruby-registry` GET left non-allowlisted vocab readable — gated to public books; `useGuestMode` failed open on a session-check error (transiently degraded signed-in chrome) — now fails closed; no way to correct a bad stored key — paid-call failures now reopen the key modal; guest library disclosed full page/char counts — capped to the preview.

## Verified

- Guest: library shows only 3 books; public book truncated to 116,290 chars / 5 pages; non-allowlisted book → 403; `/read` for a public book → 200, for others → `/login`; `/vocabulary` → `/login`; write-bookmark/vocabulary/gemini-api/write-public-txt/ruby-registry-POST → 401; translate (no key) → 401 `requiresGuestKey`.
- Signed-in: 26 directories; 幼女戦記 returns full 2.37M chars (not truncated); non-public books accessible; `/read` non-public → 200.
- `tsc --noEmit` clean, `next lint` clean on changed files, `next build` passes.

## Notes / follow-ups

- **Base branch:** stacked on `feat/tts-rest-api` because guest BYO-key TTS needs the REST-key TTS route (only on that branch, not `main`). Retarget to `main` once that merges.
- **`text-entries` PUT still open:** the EPUB pipeline PUTs without a session, and `ADMIN_API_KEY` is not currently set in `.env.local`, so gating PUT would break `epub-to-book.ts` / `batch-rephrase.ts`. Its real impact is low (it re-syncs from the server filesystem, which is empty in prod). Follow-up: set `ADMIN_API_KEY` and gate PUT to `session OR admin key`, with the pipeline sending `x-api-key`.
- **Pre-existing (not addressed here):** the wider API was already reachable without a session before this change. Destructive/management endpoints (`init-db`, `text-entries/reset`, `text-entries/sync`, `books` create, `vocabulary/[id]`) remain open and are used by owner tooling without a session — worth a separate hardening pass (e.g. an admin key for scripts) rather than folding into this feature PR.
