### PR TITLE
feat: Prioritize (beta) - per-sentence importance highlighting

### DIFF
--- a/app/api/prioritize/route.ts
+++ b/app/api/prioritize/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { getAIClient } from "@/lib/ai";
+import { AI_MODELS, GUEST_KEY_HEADERS } from "@/lib/constants";
+import { isAuthenticated } from "@/lib/auth/apiSession";
+
+export const dynamic = "force-dynamic";
+
+const MAX_SENTENCES = 60;
+
+const RATING_INSTRUCTION = `Act as an expert reading comprehension assistant. Below are numbered sentences from one page of a book. Rate the importance of EACH sentence on a scale of 1 to 5.
+
+[5] Critical: the core thesis, a major plot point, or vital information the page loses its meaning without.
+[4] High: strong supporting arguments, essential character development, or highly relevant context.
+[3] Moderate: standard narrative, dialogue, or transitional information.
+[2] Low: minor descriptive details, tangents, or repetitive supporting points.
+[1] Filler: purely atmospheric, fluff, or highly skimmable text.
+
+Respond with ONLY a JSON object of the form {"scores":[n1,n2,...]} where the array holds exactly one integer (1-5) per numbered sentence, in the same order. Output no sentences, no rationale, no other text.`;
+
+function normalizeScores(raw: unknown, count: number): number[] {
+  const list = Array.isArray(raw) ? raw : [];
+  return Array.from({ length: count }, (_, i) => {
+    const value = Math.round(Number(list[i]));
+    if (!Number.isFinite(value)) return 3;
+    return Math.min(5, Math.max(1, value));
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const authed = await isAuthenticated();
+    const guestKey = request.headers.get(GUEST_KEY_HEADERS.GEMINI);
+    if (!authed && !guestKey) {
+      return NextResponse.json(
+        { scores: [], message: "Sign in or add your own Gemini API key.", requiresGuestKey: "gemini" },
+        { status: 401 }
+      );
+    }
+
+    const { sentences } = (await request.json()) as { sentences?: unknown };
+    if (!Array.isArray(sentences) || sentences.length === 0) {
+      return NextResponse.json({ scores: [], message: "No sentences provided" }, { status: 400 });
+    }
+
+    const trimmed = sentences.slice(0, MAX_SENTENCES).map((s) => String(s));
+    const numbered = trimmed.map((sentence, index) => `${index + 1}. ${sentence}`).join("\n");
+    const prompt = `${RATING_INSTRUCTION}\n\nSentences:\n${numbered}`;
+
+    const ai = getAIClient(authed ? undefined : guestKey || undefined);
+    const response = await ai.models.generateContent({
+      model: AI_MODELS.GEMINI_3_5_FLASH,
+      contents: [{ text: prompt }],
+      config: { responseMimeType: "application/json" },
+    });
+
+    const parsed = JSON.parse(response.text || "{}");
+    const scores = normalizeScores(Array.isArray(parsed) ? parsed : parsed.scores, trimmed.length);
+
+    return NextResponse.json({ scores });
+  } catch (error) {
+    console.error("Prioritize error:", error);
+    return NextResponse.json(
+      { scores: [], message: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/prioritize/route.ts
+++ b/app/api/prioritize/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 import { getAIClient } from "@/lib/ai";
-import { AI_MODELS, GUEST_KEY_HEADERS } from "@/lib/constants";
+import { AI_MODELS, GUEST_KEY_HEADERS, PAGINATION_CONFIG, type PriorityScore } from "@/lib/constants";
 import { isAuthenticated } from "@/lib/auth/apiSession";
 
 export const dynamic = "force-dynamic";
 
-const MAX_SENTENCES = 60;
+// A reader page holds at most one screen of units, so this also bounds how many
+// sentences we ever score. Derived from the reader's paging so the two stay in
+// step -- raising items-per-page can never silently drop sentences here.
+const MAX_SENTENCES = PAGINATION_CONFIG.ITEMS_PER_PAGE;
 
 const RATING_INSTRUCTION = `Act as an expert reading comprehension assistant. Below are numbered sentences from one page of a book. Rate the importance of EACH sentence on a scale of 1 to 5.
 
@@ -17,13 +20,10 @@ const RATING_INSTRUCTION = `Act as an expert reading comprehension assistant. Be
 
 Respond with ONLY a JSON object of the form {"scores":[n1,n2,...]} where the array holds exactly one integer (1-5) per numbered sentence, in the same order. Output no sentences, no rationale, no other text.`;
 
-function normalizeScores(raw: unknown, count: number): number[] {
-  const list = Array.isArray(raw) ? raw : [];
-  return Array.from({ length: count }, (_, i) => {
-    const value = Math.round(Number(list[i]));
-    if (!Number.isFinite(value)) return 3;
-    return Math.min(5, Math.max(1, value));
-  });
+function clampScore(value: unknown): PriorityScore {
+  const rounded = Math.round(Number(value));
+  if (!Number.isFinite(rounded)) return 3;
+  return Math.min(5, Math.max(1, rounded)) as PriorityScore;
 }
 
 export async function POST(request: Request) {
@@ -54,9 +54,18 @@ export async function POST(request: Request) {
     });
 
     const parsed = JSON.parse(response.text || "{}");
-    const scores = normalizeScores(Array.isArray(parsed) ? parsed : parsed.scores, trimmed.length);
+    const rawScores = Array.isArray(parsed) ? parsed : parsed?.scores;
 
-    return NextResponse.json({ scores });
+    // A blocked/empty candidate or count mismatch must fail loudly rather than be
+    // coerced into uniform defaults the reader would show as real judgment.
+    if (!Array.isArray(rawScores) || rawScores.length !== trimmed.length) {
+      return NextResponse.json(
+        { scores: [], message: "The model did not return a score for every sentence." },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ scores: rawScores.map(clampScore) });
   } catch (error) {
     console.error("Prioritize error:", error);
     return NextResponse.json(

--- a/app/read/components/ReaderFAB.tsx
+++ b/app/read/components/ReaderFAB.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
 
 interface ReaderFABProps {
   onToggleFurigana: () => void;
@@ -21,6 +21,16 @@ interface ReaderFABProps {
   bookmarkPage?: number | null;
   currentPage?: number;
   copyFeedback: boolean;
+}
+
+interface FabMenuButton {
+  icon: ReactNode;
+  label: string;
+  action: () => void;
+  active?: boolean;
+  hidden?: boolean;
+  keepOpen?: boolean;
+  beta?: boolean;
 }
 
 const STORAGE_KEY = 'fab_position';
@@ -217,7 +227,7 @@ export default function ReaderFAB({
 
   const isOnBookmarkPage = hasBookmark && currentPage === bookmarkPage;
 
-  const fabButtons = [
+  const fabButtons: FabMenuButton[] = [
     {
       icon: (
         <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/read/components/ReaderFAB.tsx
+++ b/app/read/components/ReaderFAB.tsx
@@ -11,6 +11,9 @@ interface ReaderFABProps {
   onCopyPageRange: () => void;
   onToggleDarkMode: () => void;
   onToggleRubyLookup: () => void;
+  onPrioritize: () => void;
+  isPrioritizing?: boolean;
+  hasPriority?: boolean;
   isFuriganaEnabled: boolean;
   showRephrase: boolean;
   isDarkMode: boolean;
@@ -60,6 +63,9 @@ export default function ReaderFAB({
   onCopyPageRange,
   onToggleDarkMode,
   onToggleRubyLookup,
+  onPrioritize,
+  isPrioritizing,
+  hasPriority,
   isFuriganaEnabled,
   showRephrase,
   isDarkMode,
@@ -244,6 +250,22 @@ export default function ReaderFAB({
       action: onCopyPageRange,
     },
     {
+      icon: isPrioritizing ? (
+        <span
+          className="w-[16px] h-[16px] animate-spin"
+          style={{ borderWidth: 2, borderStyle: 'solid', borderColor: 'currentColor', borderTopColor: 'transparent', borderRadius: '50%' }}
+        />
+      ) : (
+        <svg className="w-[18px] h-[18px]" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" />
+        </svg>
+      ),
+      label: hasPriority ? 'Clear Priority' : isPrioritizing ? 'Analyzing...' : 'Prioritize',
+      action: onPrioritize,
+      active: Boolean(hasPriority),
+      beta: true,
+    },
+    {
       icon: <span className="text-xs font-semibold">R</span>,
       label: showRephrase ? 'Hide Rephrase' : 'Show Rephrase',
       action: onToggleRephrase,
@@ -368,6 +390,14 @@ export default function ReaderFAB({
                       {btn.icon}
                     </span>
                     <span className="text-[13px] font-medium whitespace-nowrap">{btn.label}</span>
+                    {btn.beta && (
+                      <span
+                        className="text-[9px] font-bold px-1.5 py-0.5 rounded-full"
+                        style={{ backgroundColor: '#FF9500', color: '#FFFFFF', letterSpacing: '0.5px' }}
+                      >
+                        BETA
+                      </span>
+                    )}
                   </button>
                 ))}
               </div>

--- a/app/read/components/ReadingContent.tsx
+++ b/app/read/components/ReadingContent.tsx
@@ -4,7 +4,7 @@ import { useMemo, type CSSProperties } from "react";
 import dynamic from "next/dynamic";
 import { parseReaderItems } from "@/lib/utils/buildPlayableUnits";
 import { stripFurigana } from "@/lib/utils/furiganaParser";
-import { PRIORITY_LEVELS } from "@/lib/constants";
+import { PRIORITY_LEVELS, type PriorityScore } from "@/lib/constants";
 
 const CollapsibleItem = dynamic(
   () => import("@/app/components/reading/CollapsibleItem"),
@@ -38,7 +38,7 @@ interface ReadingContentProps {
   startCursorIndex?: number;
   playingIndex?: number;
   onStartFromHere?: (unitIndex: number) => void;
-  priorityScores?: Record<number, number>;
+  priorityScores?: Record<number, PriorityScore>;
 }
 
 function detectContentType(text: string): ContentType {
@@ -56,9 +56,8 @@ function normalizeForComparison(text: string): string {
   return stripped.replace(/[\r\n]/g, "").trim();
 }
 
-function priorityWrapperStyle(score: number): CSSProperties {
+function priorityWrapperStyle(score: PriorityScore): CSSProperties {
   const level = PRIORITY_LEVELS[score];
-  if (!level) return {};
   return {
     position: "relative",
     borderLeft: `${level.border}px solid ${level.color}`,
@@ -69,9 +68,8 @@ function priorityWrapperStyle(score: number): CSSProperties {
   };
 }
 
-function PriorityBadge({ score }: { score: number }) {
+function PriorityBadge({ score }: { score: PriorityScore }) {
   const level = PRIORITY_LEVELS[score];
-  if (!level) return null;
   return (
     <span
       title={`Importance ${score}/5 - ${level.label}`}
@@ -182,10 +180,14 @@ export default function ReadingContent({
             />
           );
 
-          if (priorityScore === undefined) return itemEl;
+          // Always the same wrapper + key so toggling Prioritize never remounts
+          // the item (which would reset its open/translation state and flash).
           return (
-            <div key={`priority-${currentPage}-${index}`} style={priorityWrapperStyle(priorityScore)}>
-              <PriorityBadge score={priorityScore} />
+            <div
+              key={`${currentPage}-${index}`}
+              style={priorityScore !== undefined ? priorityWrapperStyle(priorityScore) : undefined}
+            >
+              {priorityScore !== undefined && <PriorityBadge score={priorityScore} />}
               {itemEl}
             </div>
           );
@@ -228,10 +230,14 @@ export default function ReadingContent({
           />
         );
 
-        if (priorityScore === undefined) return itemEl;
+        // Always the same wrapper + key so toggling Prioritize never remounts
+        // the item (which would reset its open/translation state and flash).
         return (
-          <div key={`priority-${currentPage}-${index}`} style={priorityWrapperStyle(priorityScore)}>
-            <PriorityBadge score={priorityScore} />
+          <div
+            key={`${currentPage}-${index}`}
+            style={priorityScore !== undefined ? priorityWrapperStyle(priorityScore) : undefined}
+          >
+            {priorityScore !== undefined && <PriorityBadge score={priorityScore} />}
             {itemEl}
           </div>
         );

--- a/app/read/components/ReadingContent.tsx
+++ b/app/read/components/ReadingContent.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, type CSSProperties } from "react";
 import dynamic from "next/dynamic";
 import { parseReaderItems } from "@/lib/utils/buildPlayableUnits";
 import { stripFurigana } from "@/lib/utils/furiganaParser";
+import { PRIORITY_LEVELS } from "@/lib/constants";
 
 const CollapsibleItem = dynamic(
   () => import("@/app/components/reading/CollapsibleItem"),
@@ -37,6 +38,7 @@ interface ReadingContentProps {
   startCursorIndex?: number;
   playingIndex?: number;
   onStartFromHere?: (unitIndex: number) => void;
+  priorityScores?: Record<number, number>;
 }
 
 function detectContentType(text: string): ContentType {
@@ -52,6 +54,47 @@ function detectContentType(text: string): ContentType {
 function normalizeForComparison(text: string): string {
   const stripped = stripFurigana(text);
   return stripped.replace(/[\r\n]/g, "").trim();
+}
+
+function priorityWrapperStyle(score: number): CSSProperties {
+  const level = PRIORITY_LEVELS[score];
+  if (!level) return {};
+  return {
+    position: "relative",
+    borderLeft: `${level.border}px solid ${level.color}`,
+    paddingLeft: 26,
+    opacity: level.opacity,
+    borderRadius: 4,
+    transition: "opacity 200ms ease",
+  };
+}
+
+function PriorityBadge({ score }: { score: number }) {
+  const level = PRIORITY_LEVELS[score];
+  if (!level) return null;
+  return (
+    <span
+      title={`Importance ${score}/5 - ${level.label}`}
+      style={{
+        position: "absolute",
+        left: 4,
+        top: 4,
+        width: 18,
+        height: 18,
+        borderRadius: "50%",
+        backgroundColor: level.color,
+        color: "#FFFFFF",
+        fontSize: 10,
+        fontWeight: 700,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        lineHeight: 1,
+      }}
+    >
+      {score}
+    </span>
+  );
 }
 
 export default function ReadingContent({
@@ -74,6 +117,7 @@ export default function ReadingContent({
   startCursorIndex,
   playingIndex,
   onStartFromHere,
+  priorityScores,
 }: ReadingContentProps) {
   const contentType = useMemo(() => detectContentType(content), [content]);
 
@@ -112,8 +156,9 @@ export default function ReadingContent({
             bookmarkText && normalizedHead === normalizedBookmark
           );
           const globalIndex = (currentPage - 1) * itemsPerPage + index;
+          const priorityScore = priorityScores?.[globalIndex];
 
-          return (
+          const itemEl = (
             <CollapsibleItem
               key={`${currentPage}-${index}`}
               {...(isBookmarked ? { id: "bookmark" } : {})}
@@ -136,6 +181,14 @@ export default function ReadingContent({
               onStartFromHere={onStartFromHere}
             />
           );
+
+          if (priorityScore === undefined) return itemEl;
+          return (
+            <div key={`priority-${currentPage}-${index}`} style={priorityWrapperStyle(priorityScore)}>
+              <PriorityBadge score={priorityScore} />
+              {itemEl}
+            </div>
+          );
         })}
       </div>
     );
@@ -151,8 +204,9 @@ export default function ReadingContent({
           bookmarkText && normalizedText === normalizedBookmark
         );
         const globalIndex = (currentPage - 1) * itemsPerPage + index;
+        const priorityScore = priorityScores?.[globalIndex];
 
-        return (
+        const itemEl = (
           <ParagraphItem
             key={`${currentPage}-${index}`}
             {...(isBookmarked ? { id: "bookmark" } : {})}
@@ -172,6 +226,14 @@ export default function ReadingContent({
             isPlaying={playingIndex === globalIndex}
             onStartFromHere={onStartFromHere}
           />
+        );
+
+        if (priorityScore === undefined) return itemEl;
+        return (
+          <div key={`priority-${currentPage}-${index}`} style={priorityWrapperStyle(priorityScore)}>
+            <PriorityBadge score={priorityScore} />
+            {itemEl}
+          </div>
         );
       })}
     </div>

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -24,6 +24,7 @@ import { useGuestMode } from '@/app/hooks/useGuestMode';
 import GuestModeBanner from '@/app/components/ui/GuestModeBanner';
 import { stripFurigana } from '@/lib/utils/furiganaParser';
 import { buildPlayableUnits } from '@/lib/utils/buildPlayableUnits';
+import { guestKeyHeaders, promptGuestKeyOnFailure } from '@/lib/guestKeys';
 import { useAudioBook } from '@/app/hooks/useAudioBook';
 import type { AudioBookContentMode } from '@/lib/types';
 
@@ -105,6 +106,9 @@ function ReaderContent({
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [copyRangeOpen, setCopyRangeOpen] = useState(false);
   const [copyRangeFeedback, setCopyRangeFeedback] = useState(false);
+
+  const [priorityScores, setPriorityScores] = useState<Record<number, number>>({});
+  const [isPrioritizing, setIsPrioritizing] = useState(false);
 
   const { imageMap } = useBookMetadata(fileNameParam, directoryParam);
   const { isGuest } = useGuestMode();
@@ -216,6 +220,44 @@ function ReaderContent({
     const end = start + PAGINATION_CONFIG.ITEMS_PER_PAGE;
     return playableUnits.slice(start, end).map(unit => stripFurigana(unit.main));
   }, [playableUnits, currentPage]);
+
+  // Priority scores are per-page; drop them when the page or book changes.
+  useEffect(() => {
+    setPriorityScores({});
+  }, [currentPage, fullFilePath]);
+
+  const handlePrioritize = useCallback(async () => {
+    if (isPrioritizing || currentPageHeaders.length === 0) return;
+    if (Object.keys(priorityScores).length > 0) {
+      setPriorityScores({});
+      return;
+    }
+
+    setIsPrioritizing(true);
+    try {
+      const res = await fetch(API_ROUTES.PRIORITIZE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...guestKeyHeaders('gemini') },
+        body: JSON.stringify({ sentences: currentPageHeaders }),
+      });
+      if (!res.ok) {
+        await promptGuestKeyOnFailure('gemini', res);
+        throw new Error('Prioritize request failed');
+      }
+      const data = await res.json();
+      const scores: number[] = Array.isArray(data.scores) ? data.scores : [];
+      const start = (currentPage - 1) * PAGINATION_CONFIG.ITEMS_PER_PAGE;
+      const scored: Record<number, number> = {};
+      scores.forEach((score, index) => {
+        scored[start + index] = score;
+      });
+      setPriorityScores(scored);
+    } catch (err) {
+      console.error('Prioritize failed:', err);
+    } finally {
+      setIsPrioritizing(false);
+    }
+  }, [currentPageHeaders, currentPage, priorityScores, isPrioritizing]);
 
   const bookmarkItemIndex = useMemo(() => {
     if (!bookmarkText || /^page:\d+$/.test(bookmarkText)) return null;
@@ -585,6 +627,35 @@ function ReaderContent({
         />
       )}
 
+      {isPrioritizing && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: audiobookEnabled ? 150 : 24,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 60,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 16px',
+            borderRadius: 999,
+            backgroundColor: isDarkMode ? DARK_COLORS.SURFACE : '#FFFFFF',
+            color: isDarkMode ? DARK_COLORS.TEXT : '#1D1D1F',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.18)',
+            border: isDarkMode ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(0,0,0,0.06)',
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          <span
+            className="animate-spin"
+            style={{ width: 14, height: 14, borderWidth: 2, borderStyle: 'solid', borderColor: '#FF9500', borderTopColor: 'transparent', borderRadius: '50%' }}
+          />
+          Analyzing importance...
+        </div>
+      )}
+
       <ProgressBar progress={progress} />
 
       <ReaderHeader
@@ -625,6 +696,7 @@ function ReaderContent({
           startCursorIndex={audioStartCursor}
           playingIndex={audioStatus === 'idle' ? -1 : audioIndex}
           onStartFromHere={setStartCursor}
+          priorityScores={priorityScores}
         />
 
         {totalPages > 1 && (
@@ -697,6 +769,9 @@ function ReaderContent({
         onCopyPageRange={() => setCopyRangeOpen(true)}
         onToggleDarkMode={handleToggleDarkMode}
         onToggleRubyLookup={() => setRubyLookupOpen(prev => !prev)}
+        onPrioritize={handlePrioritize}
+        isPrioritizing={isPrioritizing}
+        hasPriority={Object.keys(priorityScores).length > 0}
         isFuriganaEnabled={showFurigana}
         showRephrase={showRephrase}
         isDarkMode={isDarkMode}

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -11,6 +11,7 @@ import {
   STORAGE_KEYS,
   PAGINATION_CONFIG,
   API_ROUTES,
+  type PriorityScore,
 } from '@/lib/constants';
 import ProgressBar from './components/ProgressBar';
 import ReaderFAB from './components/ReaderFAB';
@@ -107,8 +108,9 @@ function ReaderContent({
   const [copyRangeOpen, setCopyRangeOpen] = useState(false);
   const [copyRangeFeedback, setCopyRangeFeedback] = useState(false);
 
-  const [priorityScores, setPriorityScores] = useState<Record<number, number>>({});
+  const [priorityScores, setPriorityScores] = useState<Record<number, PriorityScore>>({});
   const [isPrioritizing, setIsPrioritizing] = useState(false);
+  const [prioritizeError, setPrioritizeError] = useState<string | null>(null);
 
   const { imageMap } = useBookMetadata(fileNameParam, directoryParam);
   const { isGuest } = useGuestMode();
@@ -221,10 +223,17 @@ function ReaderContent({
     return playableUnits.slice(start, end).map(unit => stripFurigana(unit.main));
   }, [playableUnits, currentPage]);
 
-  // Priority scores are per-page; drop them when the page or book changes.
+  // Priority scores are per-page; drop them (and any error) on page/book change.
   useEffect(() => {
     setPriorityScores({});
+    setPrioritizeError(null);
   }, [currentPage, fullFilePath]);
+
+  useEffect(() => {
+    if (!prioritizeError) return;
+    const timer = setTimeout(() => setPrioritizeError(null), 4000);
+    return () => clearTimeout(timer);
+  }, [prioritizeError]);
 
   const handlePrioritize = useCallback(async () => {
     if (isPrioritizing || currentPageHeaders.length === 0) return;
@@ -233,6 +242,7 @@ function ReaderContent({
       return;
     }
 
+    setPrioritizeError(null);
     setIsPrioritizing(true);
     try {
       const res = await fetch(API_ROUTES.PRIORITIZE, {
@@ -241,19 +251,23 @@ function ReaderContent({
         body: JSON.stringify({ sentences: currentPageHeaders }),
       });
       if (!res.ok) {
-        await promptGuestKeyOnFailure('gemini', res);
-        throw new Error('Prioritize request failed');
+        // Missing/invalid guest key opens the key modal; anything else is a real
+        // failure the reader should see rather than a silent empty result.
+        if (res.status === 401) {
+          await promptGuestKeyOnFailure('gemini', res);
+        } else {
+          setPrioritizeError('Could not analyze this page. Please try again.');
+        }
+        return;
       }
       const data = await res.json();
-      const scores: number[] = Array.isArray(data.scores) ? data.scores : [];
+      const scores = (Array.isArray(data.scores) ? data.scores : []) as PriorityScore[];
       const start = (currentPage - 1) * PAGINATION_CONFIG.ITEMS_PER_PAGE;
-      const scored: Record<number, number> = {};
-      scores.forEach((score, index) => {
-        scored[start + index] = score;
-      });
-      setPriorityScores(scored);
-    } catch (err) {
-      console.error('Prioritize failed:', err);
+      setPriorityScores(
+        Object.fromEntries(scores.map((score, index) => [start + index, score] as const))
+      );
+    } catch {
+      setPrioritizeError('Could not analyze this page. Please try again.');
     } finally {
       setIsPrioritizing(false);
     }
@@ -653,6 +667,28 @@ function ReaderContent({
             style={{ width: 14, height: 14, borderWidth: 2, borderStyle: 'solid', borderColor: '#FF9500', borderTopColor: 'transparent', borderRadius: '50%' }}
           />
           Analyzing importance...
+        </div>
+      )}
+
+      {prioritizeError && !isPrioritizing && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: audiobookEnabled ? 150 : 24,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 60,
+            padding: '8px 16px',
+            borderRadius: 999,
+            backgroundColor: isDarkMode ? DARK_COLORS.SURFACE : '#FFFFFF',
+            color: '#FF3B30',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.18)',
+            border: '1px solid rgba(255,59,48,0.3)',
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          {prioritizeError}
         </div>
       )}
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -27,6 +27,7 @@ export const AI_MODELS = {
   GEMINI_FLASH: 'gemini-2.0-flash-exp',
   GEMINI_2_5_FLASH: 'gemini-2.5-flash',
   GEMINI_2_5_FLASH_LITE: 'gemini-2.5-flash-lite',
+  GEMINI_3_5_FLASH: 'gemini-3.5-flash',
   GEMINI_PRO: 'gemini-1.5-pro-latest',
 } as const;
 
@@ -70,6 +71,7 @@ export const API_ROUTES = {
   WRITE_BOOKMARK: '/api/write-bookmark',
   LIST_TEXT_FILES: '/api/list-text-files',
   EXPLAIN_SENTENCE: '/api/explain-sentence',
+  PRIORITIZE: '/api/prioritize',
   VOCABULARY: '/api/vocabulary',
   AUTH_LOGIN: '/api/auth?action=login',
   AUTH_LOGOUT: '/api/auth?action=logout',
@@ -95,6 +97,17 @@ export const GUEST_KEY_HEADERS = {
   TTS: 'x-guest-tts-key',
   TRANSLATE: 'x-guest-translate-key',
 } as const;
+
+// "Prioritize" beta: how each per-sentence importance score (1-5) is rendered.
+// High scores stay fully visible with a warm accent; low scores fade so the
+// reader can skim to what matters.
+export const PRIORITY_LEVELS: Record<number, { color: string; opacity: number; border: number; label: string }> = {
+  5: { color: '#FF3B30', opacity: 1, border: 4, label: 'Critical' },
+  4: { color: '#FF9500', opacity: 1, border: 3, label: 'High' },
+  3: { color: '#FFCC00', opacity: 0.9, border: 3, label: 'Moderate' },
+  2: { color: '#AEAEB2', opacity: 0.6, border: 2, label: 'Low' },
+  1: { color: '#C7C7CC', opacity: 0.45, border: 2, label: 'Filler' },
+};
 
 // ページルート
 export const PAGE_ROUTES = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -98,10 +98,19 @@ export const GUEST_KEY_HEADERS = {
   TRANSLATE: 'x-guest-translate-key',
 } as const;
 
-// "Prioritize" beta: how each per-sentence importance score (1-5) is rendered.
-// High scores stay fully visible with a warm accent; low scores fade so the
-// reader can skim to what matters.
-export const PRIORITY_LEVELS: Record<number, { color: string; opacity: number; border: number; label: string }> = {
+// "Prioritize" beta: presentation metadata for each importance score (1 = least
+// important, 5 = most). `color`/`border` accent the unit, `opacity` dims it, and
+// `label` names the level; how the reader applies them lives in ReadingContent.
+export type PriorityScore = 1 | 2 | 3 | 4 | 5;
+
+export interface PriorityLevel {
+  color: string;
+  opacity: number;
+  border: number;
+  label: string;
+}
+
+export const PRIORITY_LEVELS: Record<PriorityScore, PriorityLevel> = {
   5: { color: '#FF3B30', opacity: 1, border: 4, label: 'Critical' },
   4: { color: '#FF9500', opacity: 1, border: 3, label: 'High' },
   3: { color: '#FFCC00', opacity: 0.9, border: 3, label: 'Moderate' },


### PR DESCRIPTION
## Prioritize (beta)

A fun beta that helps you skim to what matters: tap **Prioritize** (in the reader FAB, with a **BETA** badge) and it rates every sentence on the current page 1-5 for importance, then color-codes each one.

### How it works
- **`POST /api/prioritize`** sends the current page's sentences (numbered) to **`gemini-3.5-flash`** and gets back a compact `{"scores":[...]}` array — no echoed sentences, one integer per sentence. Scores are clamped to 1-5 and length-matched server-side.
- Guests use their **own** Gemini key (same BYO-key flow as AI explanations); owner uses the server key. Guest-with-no-key -> 401 `requiresGuestKey`.
- The reader color-codes each unit: **red left-border = Critical (5)** -> orange/yellow (High/Moderate) -> **dimmed gray = Filler (1)**, with a small score badge. An "Analyzing importance..." pill shows while it runs; tap again to **Clear**; scores reset on page change.

### Notes
- `gemini-3.5-flash` (stable) is slower than Flash-Lite (~5.8s/page) because it "thinks" by default. A low `thinking_level` can speed it up if wanted; left at default for judgment quality.
- Verified end-to-end against real Gemini (scores came back semantically correct), and the button + highlighting confirmed in a browser. `tsc` / `next lint` / `next build` clean.
