### PR TITLE
fix: stack reader action buttons below text on mobile

### DIFF
--- a/app/components/reading/CollapsibleItem.tsx
+++ b/app/components/reading/CollapsibleItem.tsx
@@ -501,7 +501,7 @@ const CollapsibleItem: React.FC<CollapsibleItemProps> = ({
         }}
         id="collapsible-item"
       >
-        <div className="flex items-start gap-2">
+        <div className="flex flex-col sm:flex-row sm:items-start gap-2">
           <div className="flex-1 min-w-0">
             <div
               className="head-text font-bold text-lg whitespace-pre-wrap"
@@ -517,7 +517,7 @@ const CollapsibleItem: React.FC<CollapsibleItemProps> = ({
               {renderHeadWithImages()}
             </div>
           </div>
-          <div className="flex items-center gap-0.5 flex-shrink-0 pt-0.5">
+          <div className="flex items-center gap-0.5 flex-shrink-0 pt-0.5 self-end sm:self-auto">
             {audiobookEnabled && onStartFromHere && globalIndex != null && (
               <button
                 onClick={(e) => {


### PR DESCRIPTION
## Problem

On phones the reader's per-paragraph action buttons (start-here, play/TTS, translate, bookmark, expand) sit in a fixed-width column to the right of the text. With up to five 32px buttons that column reserves ~160px, crushing the Japanese text into a narrow strip on the left.

This affects `CollapsibleItem` (the rephrase reader, which is the main reading interface). `ParagraphItem` positions its buttons absolutely and is unaffected.

## Fix

On narrow screens (`< sm`), stack the button row below the text at full width and right-align it; keep the existing side-by-side layout on `sm` and up.

- Outer container: `flex items-start` -> `flex flex-col sm:flex-row sm:items-start`
- Button group: add `self-end sm:self-auto` so it right-aligns under the text on mobile

No behavior or desktop-layout changes; purely responsive layout classes.