### PR TITLE
fix: always redirect root to library

### DIFF
--- a/app/components/ui/TopNavigation.tsx
+++ b/app/components/ui/TopNavigation.tsx
@@ -151,7 +151,7 @@ export default function TopNavigation() {
   const toggleDropdownState = () => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('dropdownAlwaysOpen', (!dropdownAlwaysOpen).toString());
-    router.push(`/?${params.toString()}`);
+    router.push(`${pathname}?${params.toString()}`);
   };
 
   const closeMobileMenu = () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,15 @@
 'use client';
 
-import { useEffect, Suspense } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { READER_THEME, COLORS } from '@/lib/constants';
 
-function HomeRedirect() {
+export default function Home() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const directory = searchParams.get('directory');
-  const fileName = searchParams.get('fileName');
 
   useEffect(() => {
-    if (directory && fileName) {
-      const params = new URLSearchParams();
-      params.set('directory', directory);
-      params.set('fileName', fileName);
-      const page = searchParams.get('page');
-      if (page) params.set('page', page);
-      router.replace(`/read?${params.toString()}`);
-    } else {
-      router.replace('/library');
-    }
-  }, [directory, fileName, router, searchParams]);
+    router.replace('/library');
+  }, [router]);
 
   return (
     <div
@@ -36,28 +24,5 @@ function HomeRedirect() {
         }}
       />
     </div>
-  );
-}
-
-export default function Home() {
-  return (
-    <Suspense
-      fallback={
-        <div
-          className="min-h-screen flex items-center justify-center"
-          style={{ backgroundColor: READER_THEME.SURFACE_MUTED }}
-        >
-          <div
-            className="w-12 h-12 border-4 rounded-full animate-spin"
-            style={{
-              borderColor: COLORS.NEUTRAL,
-              borderTopColor: COLORS.PRIMARY,
-            }}
-          />
-        </div>
-      }
-    >
-      <HomeRedirect />
-    </Suspense>
   );
 }

--- a/app/vocabulary/page.tsx
+++ b/app/vocabulary/page.tsx
@@ -81,7 +81,7 @@ export default function VocabularyPage() {
       fileName: entry.fileName,
       highlight: entry.word,
     });
-    router.push(`/?${params.toString()}`);
+    router.push(`/read?${params.toString()}`);
   };
 
   const formatDate = (dateString: string | Date) => {


### PR DESCRIPTION
## What

Make the root route (`/`) always redirect to `/library`.

## Why

Opening `/` with `?directory=...&fileName=...` query params (e.g. a browser-restored tab or an old bookmark) used to forward to `/read`, so a restored session tab would jump straight into a book instead of the library home. The library is the intended homepage.

## Details

- Removed the `if (directory && fileName)` forwarding branch in `app/page.tsx`, plus the now-unused `useSearchParams`/`Suspense` that only existed to read those params.

## Follow-up fix (from PR review)

The initial description wrongly claimed no in-app code generates a param'd root URL. Two call sites did, and relied on the deleted forwarding branch as a trampoline into `/read`:

- `app/vocabulary/page.tsx` `navigateToSource` (the vocabulary "jump to source" button) pushed `/?directory&fileName&highlight`. Repointed to `/read?...` (mirrors `BookCard`) so the book opens directly. Note: `/read` reads only `directory`/`fileName`/`page`, so `highlight` was already a no-op through the old trampoline too - unchanged behavior, out of scope.
- `app/components/ui/TopNavigation.tsx` `toggleDropdownState` pushed `/?${params}` instead of `${pathname}?${params}` like its sibling handlers, so toggling on the reader dropped context to `/library`. Repointed to `${pathname}?...`.

With these, the root simplification no longer regresses any live navigation.