### PR TITLE
feat: play the real audiobook narration instead of TTS

### DIFF
--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -16,6 +16,7 @@ interface PlayStep {
 
 const MAX_CONSECUTIVE_FAILURES = 3;
 const NARRATION_LOAD_TIMEOUT_MS = 20000;
+const TTS_FETCH_TIMEOUT_MS = 30000;
 
 interface UseAudioBookOptions {
   units: PlayableUnit[];
@@ -26,13 +27,12 @@ interface UseAudioBookOptions {
 }
 
 /**
- * Seeks once the recording knows its duration, clamped so a cue that runs past
- * the decoded end (chapter marks routinely do) still lands inside the media.
- * Rejects rather than waiting forever when the media never becomes seekable.
+ * Rejects when `work` outlives `timeoutMs`. The losing side keeps running, so a
+ * caller that owns media or a request has to stop it on rejection itself.
  */
-function withTimeout<T>(work: Promise<T>, message: string): Promise<T> {
+function withTimeout<T>(work: Promise<T>, message: string, timeoutMs: number): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(message)), NARRATION_LOAD_TIMEOUT_MS);
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
     work.then(
       (value) => { clearTimeout(timer); resolve(value); },
       (error) => { clearTimeout(timer); reject(error); }
@@ -40,6 +40,11 @@ function withTimeout<T>(work: Promise<T>, message: string): Promise<T> {
   });
 }
 
+/**
+ * Seeks once the recording knows its duration, clamped so a cue that runs past
+ * the decoded end (chapter marks routinely do) still lands inside the media.
+ * Rejects rather than waiting forever when the media never becomes seekable.
+ */
 function seekTo(audio: HTMLAudioElement, time: number): Promise<void> {
   const applySeek = () => {
     audio.currentTime = isFinite(audio.duration) ? Math.min(time, audio.duration) : time;
@@ -63,6 +68,7 @@ function seekTo(audio: HTMLAudioElement, time: number): Promise<void> {
     });
     const onFailed = () => settle(() => reject(new Error('Narration audio failed to load')));
     const timer = setTimeout(onFailed, NARRATION_LOAD_TIMEOUT_MS);
+
 
     audio.addEventListener('loadedmetadata', onLoaded);
     audio.addEventListener('error', onFailed);
@@ -116,7 +122,7 @@ export function useAudioBook({
   const [status, setStatus] = useState<AudioBookStatus>('idle');
   const [index, setIndex] = useState(-1);
   const [cursor, setCursor] = useState(-1);
-  const [narrationError, setNarrationError] = useState<string | null>(null);
+  const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [narrationDisabled, setNarrationDisabled] = useState(false);
   const [speed, setSpeedState] = useState<number>(TTS_CONFIG.DEFAULT_SPEED);
   const [voiceGender, setVoiceGenderState] = useState<TTSVoiceGender>(TTS_CONFIG.DEFAULT_VOICE_GENDER);
@@ -239,7 +245,9 @@ export function useAudioBook({
 
   const acquireNarrationAudio = useCallback((audioUrl: string) => {
     const existing = narrationAudioRef.current;
-    if (existing && narrationUrlRef.current === audioUrl) return existing;
+    // An element that already failed keeps its error and never re-fires load
+    // events, so reusing it would make every retry wait out the load timeout.
+    if (existing && narrationUrlRef.current === audioUrl && !existing.error) return existing;
     releaseNarrationAudio();
     const audio = new Audio(audioUrl);
     audio.preload = 'auto';
@@ -301,8 +309,13 @@ export function useAudioBook({
   // it stops playback instead of skipping ahead like the TTS path does.
   const playNarration = useCallback(async (step: PlayStep, cue: NarrationCue, token: number) => {
     const stopOnFailure = (error: unknown) => {
-      if (token !== playTokenRef.current) return;
       console.error('Narration playback failed:', error);
+      // A superseded step must not touch playback state, but its element still
+      // has to go: leaving an errored one cached poisons the next attempt.
+      if (token !== playTokenRef.current) {
+        if (narrationAudioRef.current?.error) releaseNarrationAudio();
+        return;
+      }
       isAutoRef.current = false;
       // Retrying a broken recording forever would leave the book unplayable even
       // though speech synthesis could read it, so give up on the recording and
@@ -313,7 +326,7 @@ export function useAudioBook({
         narrationDisabledRef.current = true;
         setNarrationDisabled(true);
       }
-      setNarrationError(givingUp
+      setPlaybackError(givingUp
         ? 'Audiobook recording unavailable, reading with speech synthesis'
         : 'Audiobook recording could not be played');
       // A failed element keeps its error state and will not re-fire load events,
@@ -362,14 +375,14 @@ export function useAudioBook({
       }
       // Seeking into an unbuffered range can leave play() pending indefinitely on
       // a hung range request, which would pin the player on its loading spinner.
-      await withTimeout(audio.play(), 'Narration audio did not start playing');
+      await withTimeout(audio.play(), 'Narration audio did not start playing', NARRATION_LOAD_TIMEOUT_MS);
     } catch (error) {
       stopOnFailure(error);
       return;
     }
     if (token !== playTokenRef.current) return;
     narrationFailuresRef.current = 0;
-    setNarrationError(null);
+    setPlaybackError(null);
     updateStatus('playing');
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
@@ -397,10 +410,17 @@ export function useAudioBook({
 
     let audioBase64: string | null = null;
     try {
-      audioBase64 = await fetchTTS({ text: text ?? '', speed: 1, voiceGender: voiceRef.current });
+      // Without a deadline a hung /api/tts leaves status on 'loading', where
+      // togglePlayPause refuses to act and the player looks frozen.
+      audioBase64 = await withTimeout(
+        fetchTTS({ text: text ?? '', speed: 1, voiceGender: voiceRef.current }),
+        'Speech synthesis did not respond',
+        TTS_FETCH_TIMEOUT_MS
+      );
     } catch (error) {
       if (token !== playTokenRef.current) return;
       console.error('Audiobook TTS fetch failed:', error);
+      setPlaybackError('Speech synthesis failed');
       skipOrEndOnFailure(token);
       return;
     }
@@ -419,6 +439,7 @@ export function useAudioBook({
     audio.onerror = () => {
       if (token !== playTokenRef.current) return;
       console.error('Audiobook clip failed to decode/play');
+      setPlaybackError('Speech synthesis clip could not be played');
       skipOrEndOnFailure(token);
     };
     audioRef.current = audio;
@@ -428,11 +449,13 @@ export function useAudioBook({
     } catch (error) {
       if (token !== playTokenRef.current) return;
       console.error('Audiobook playback failed:', error);
+      setPlaybackError('Playback could not start');
       isAutoRef.current = false;
       updateStatus('idle');
       return;
     }
     if (token !== playTokenRef.current) return;
+    setPlaybackError(null);
     updateStatus('playing');
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
@@ -475,7 +498,7 @@ export function useAudioBook({
     phaseRef.current = 'main';
     updateIndex(-1);
     clearStartCursor();
-    setNarrationError(null);
+    setPlaybackError(null);
     updateStatus('idle');
   }, [clearStartCursor, detachAudio, updateIndex, updateStatus]);
 
@@ -543,7 +566,7 @@ export function useAudioBook({
     statusRef.current = 'idle';
     setIndex(-1);
     setCursor(-1);
-    setNarrationError(null);
+    setPlaybackError(null);
     setStatus('idle');
   }, [units, detachAudio]);
 
@@ -562,7 +585,7 @@ export function useAudioBook({
     total: units.length,
     speed,
     hasNarration,
-    narrationError,
+    playbackError,
     togglePlayPause,
     pause,
     resume,

--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -189,10 +189,10 @@ export function useAudioBook({
     setStatus(next);
   }, []);
 
-  const releaseNarrationAudio = useCallback(() => {
+  /** Drops the cached recording. Returns whether it was the element being played. */
+  const discardNarrationAudio = useCallback(() => {
     const audio = narrationAudioRef.current;
-    if (!audio) return;
-    const wasPlayingThrough = audioRef.current === audio;
+    if (!audio) return false;
     audio.ontimeupdate = null;
     audio.onended = null;
     audio.onerror = null;
@@ -200,14 +200,18 @@ export function useAudioBook({
     audio.src = '';
     narrationAudioRef.current = null;
     narrationUrlRef.current = null;
-    if (!wasPlayingThrough) return;
+    return audioRef.current === audio;
+  }, []);
+
+  const releaseNarrationAudio = useCallback(() => {
+    if (!discardNarrationAudio()) return;
     // Dropping the recording mid-sentence has to cancel the play in flight too,
     // or the player keeps reporting itself as playing with nothing to play.
     audioRef.current = null;
     playTokenRef.current++;
     isAutoRef.current = false;
     updateStatus('idle');
-  }, [updateStatus]);
+  }, [discardNarrationAudio, updateStatus]);
 
   useEffect(() => {
     if (narration?.audioUrl === narrationUrlRef.current) return;
@@ -310,10 +314,11 @@ export function useAudioBook({
   const playNarration = useCallback(async (step: PlayStep, cue: NarrationCue, token: number) => {
     const stopOnFailure = (error: unknown) => {
       console.error('Narration playback failed:', error);
-      // A superseded step must not touch playback state, but its element still
-      // has to go: leaving an errored one cached poisons the next attempt.
+      // A superseded step must not touch playback state -- the step that replaced
+      // it may already be mid-flight -- but its element still has to go, since
+      // leaving an errored one cached poisons the next attempt.
       if (token !== playTokenRef.current) {
-        if (narrationAudioRef.current?.error) releaseNarrationAudio();
+        if (narrationAudioRef.current?.error) discardNarrationAudio();
         return;
       }
       isAutoRef.current = false;
@@ -387,7 +392,7 @@ export function useAudioBook({
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
     prefetch(step);
-  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, prefetch, releaseNarrationAudio, updateStatus]);
+  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, discardNarrationAudio, prefetch, releaseNarrationAudio, updateStatus]);
 
   const playStep = useCallback(async (step: PlayStep, isAuto: boolean) => {
     const units2 = unitsRef.current;

--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -279,17 +279,25 @@ export function useAudioBook({
   // A narration failure is a whole-recording problem rather than a bad clip, so
   // it stops playback instead of skipping ahead like the TTS path does.
   const playNarration = useCallback(async (step: PlayStep, cue: NarrationCue, token: number) => {
-    const manifest = narrationRef.current;
-    if (!manifest) return;
-
     const stopOnFailure = (error: unknown) => {
       if (token !== playTokenRef.current) return;
       console.error('Narration playback failed:', error);
       isAutoRef.current = false;
       setNarrationError('Audiobook recording could not be played');
+      // A failed element keeps its error state and will not re-fire load events,
+      // so leaving it cached would make every retry wait out the load timeout.
+      releaseNarrationAudio();
       updateStatus('idle');
     };
 
+    const manifest = narrationRef.current;
+    if (!manifest) {
+      stopOnFailure(new Error('Narration manifest disappeared mid-step'));
+      return;
+    }
+
+    // detachAudio must run first: it clears audioRef so the release inside
+    // acquireNarrationAudio cannot mistake this play for one it should cancel.
     detachAudio();
     const audio = acquireNarrationAudio(manifest.audioUrl);
     audio.playbackRate = speedRef.current;
@@ -313,6 +321,13 @@ export function useAudioBook({
     try {
       await seekTo(audio, cue.start);
       if (token !== playTokenRef.current) return;
+      // A cue starting past the end means the hosted recording is shorter than the
+      // one it was aligned against. Playing anyway restarts the media from zero,
+      // which ends, advances, and loops the whole book forever.
+      if (isFinite(audio.duration) && cue.start >= audio.duration) {
+        stopOnFailure(new Error(`Cue starts at ${cue.start}s, past the ${audio.duration}s recording`));
+        return;
+      }
       await audio.play();
     } catch (error) {
       stopOnFailure(error);
@@ -324,7 +339,7 @@ export function useAudioBook({
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
     prefetch(step);
-  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, prefetch, updateStatus]);
+  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, prefetch, releaseNarrationAudio, updateStatus]);
 
   const playStep = useCallback(async (step: PlayStep, isAuto: boolean) => {
     const units2 = unitsRef.current;
@@ -425,6 +440,7 @@ export function useAudioBook({
     phaseRef.current = 'main';
     updateIndex(-1);
     clearStartCursor();
+    setNarrationError(null);
     updateStatus('idle');
   }, [clearStartCursor, detachAudio, updateIndex, updateStatus]);
 
@@ -492,6 +508,7 @@ export function useAudioBook({
     statusRef.current = 'idle';
     setIndex(-1);
     setCursor(-1);
+    setNarrationError(null);
     setStatus('idle');
   }, [units, detachAudio]);
 

--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { STORAGE_KEYS, TTS_CONFIG, type TTSVoiceGender } from '@/lib/constants';
 import type { AudioBookContentMode, NarrationCue, NarrationManifest, PlayableUnit } from '@/lib/types';
 import { cleanTextForTTS } from '@/lib/utils/ttsTextCleaner';
@@ -15,6 +15,7 @@ interface PlayStep {
 }
 
 const MAX_CONSECUTIVE_FAILURES = 3;
+const NARRATION_LOAD_TIMEOUT_MS = 20000;
 
 interface UseAudioBookOptions {
   units: PlayableUnit[];
@@ -24,17 +25,37 @@ interface UseAudioBookOptions {
   getStartIndex?: () => number;
 }
 
+/**
+ * Seeks once the recording knows its duration, clamped so a cue that runs past
+ * the decoded end (chapter marks routinely do) still lands inside the media.
+ * Rejects rather than waiting forever when the media never becomes seekable.
+ */
 function seekTo(audio: HTMLAudioElement, time: number): Promise<void> {
+  const applySeek = () => {
+    audio.currentTime = isFinite(audio.duration) ? Math.min(time, audio.duration) : time;
+  };
+
   if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) {
-    audio.currentTime = time;
+    applySeek();
     return Promise.resolve();
   }
+
   return new Promise((resolve, reject) => {
-    audio.addEventListener('loadedmetadata', () => {
-      audio.currentTime = time;
+    const settle = (finish: () => void) => {
+      clearTimeout(timer);
+      audio.removeEventListener('loadedmetadata', onLoaded);
+      audio.removeEventListener('error', onFailed);
+      finish();
+    };
+    const onLoaded = () => settle(() => {
+      applySeek();
       resolve();
-    }, { once: true });
-    audio.addEventListener('error', () => reject(new Error('Narration audio failed to load')), { once: true });
+    });
+    const onFailed = () => settle(() => reject(new Error('Narration audio failed to load')));
+    const timer = setTimeout(onFailed, NARRATION_LOAD_TIMEOUT_MS);
+
+    audio.addEventListener('loadedmetadata', onLoaded);
+    audio.addEventListener('error', onFailed);
   });
 }
 
@@ -85,6 +106,7 @@ export function useAudioBook({
   const [status, setStatus] = useState<AudioBookStatus>('idle');
   const [index, setIndex] = useState(-1);
   const [cursor, setCursor] = useState(-1);
+  const [narrationError, setNarrationError] = useState<string | null>(null);
   const [speed, setSpeedState] = useState<number>(TTS_CONFIG.DEFAULT_SPEED);
   const [voiceGender, setVoiceGenderState] = useState<TTSVoiceGender>(TTS_CONFIG.DEFAULT_VOICE_GENDER);
 
@@ -109,22 +131,11 @@ export function useAudioBook({
   const playStepRef = useRef<(step: PlayStep, isAuto: boolean) => void>(() => {});
   const consecutiveFailuresRef = useRef(0);
 
-  const releaseNarrationAudio = useCallback(() => {
-    const audio = narrationAudioRef.current;
-    if (!audio) return;
-    if (audioRef.current === audio) audioRef.current = null;
-    audio.ontimeupdate = null;
-    audio.onerror = null;
-    audio.pause();
-    audio.src = '';
-    narrationAudioRef.current = null;
-    narrationUrlRef.current = null;
-  }, []);
+  // A manifest whose cues are all null covers nothing, so playback stays on TTS
+  // and the player must not claim otherwise.
+  const hasNarration = useMemo(() => Boolean(narration?.cues.some(Boolean)), [narration]);
 
-  useEffect(() => {
-    narrationRef.current = narration;
-    if (narration?.audioUrl !== narrationUrlRef.current) releaseNarrationAudio();
-  }, [narration, releaseNarrationAudio]);
+  useEffect(() => { narrationRef.current = narration; }, [narration]);
   useEffect(() => { contentModeRef.current = contentMode; }, [contentMode]);
   useEffect(() => { speedRef.current = speed; }, [speed]);
   useEffect(() => { voiceRef.current = voiceGender; }, [voiceGender]);
@@ -150,6 +161,31 @@ export function useAudioBook({
     statusRef.current = next;
     setStatus(next);
   }, []);
+
+  const releaseNarrationAudio = useCallback(() => {
+    const audio = narrationAudioRef.current;
+    if (!audio) return;
+    const wasPlayingThrough = audioRef.current === audio;
+    audio.ontimeupdate = null;
+    audio.onended = null;
+    audio.onerror = null;
+    audio.pause();
+    audio.src = '';
+    narrationAudioRef.current = null;
+    narrationUrlRef.current = null;
+    if (!wasPlayingThrough) return;
+    // Dropping the recording mid-sentence has to cancel the play in flight too,
+    // or the player keeps reporting itself as playing with nothing to play.
+    audioRef.current = null;
+    playTokenRef.current++;
+    isAutoRef.current = false;
+    updateStatus('idle');
+  }, [updateStatus]);
+
+  useEffect(() => {
+    if (narration?.audioUrl === narrationUrlRef.current) return;
+    releaseNarrationAudio();
+  }, [narration, releaseNarrationAudio]);
 
   const updateIndex = useCallback((next: number) => {
     indexRef.current = next;
@@ -242,7 +278,7 @@ export function useAudioBook({
 
   // A narration failure is a whole-recording problem rather than a bad clip, so
   // it stops playback instead of skipping ahead like the TTS path does.
-  const playNarration = useCallback(async (cue: NarrationCue, token: number) => {
+  const playNarration = useCallback(async (step: PlayStep, cue: NarrationCue, token: number) => {
     const manifest = narrationRef.current;
     if (!manifest) return;
 
@@ -250,20 +286,27 @@ export function useAudioBook({
       if (token !== playTokenRef.current) return;
       console.error('Narration playback failed:', error);
       isAutoRef.current = false;
+      setNarrationError('Audiobook recording could not be played');
       updateStatus('idle');
     };
 
     detachAudio();
     const audio = acquireNarrationAudio(manifest.audioUrl);
     audio.playbackRate = speedRef.current;
-    // timeupdate only fires a few times per second, but every cue ends where the
-    // narrator pauses, so the overshoot lands in silence rather than the next line.
+    // timeupdate fires a few times per second, so playback overshoots the cue end
+    // slightly -- more so above 1x, since the cadence is wall clock rather than
+    // media time. Aligned cues normally end in the narrator's pause, which absorbs
+    // it; interpolated cues can clip. Chosen over requestAnimationFrame because
+    // that stops firing in a background tab, which is a normal way to listen.
     audio.ontimeupdate = () => {
       if (audio.currentTime < cue.end) return;
       audio.ontimeupdate = null;
       audio.pause();
       advanceAfter(token);
     };
+    // The recording can run out before the cue end is crossed, which would
+    // otherwise leave playback stuck reporting itself as playing.
+    audio.onended = () => advanceAfter(token);
     audio.onerror = () => stopOnFailure(audio.error);
     audioRef.current = audio;
 
@@ -276,10 +319,12 @@ export function useAudioBook({
       return;
     }
     if (token !== playTokenRef.current) return;
+    setNarrationError(null);
     updateStatus('playing');
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
-  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, updateStatus]);
+    prefetch(step);
+  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, prefetch, updateStatus]);
 
   const playStep = useCallback(async (step: PlayStep, isAuto: boolean) => {
     const units2 = unitsRef.current;
@@ -293,7 +338,7 @@ export function useAudioBook({
 
     const cue = cueForStep(step);
     if (cue) {
-      await playNarration(cue, token);
+      await playNarration(step, cue, token);
       return;
     }
 
@@ -464,7 +509,8 @@ export function useAudioBook({
     cursor,
     total: units.length,
     speed,
-    hasNarration: Boolean(narration),
+    hasNarration,
+    narrationError,
     togglePlayPause,
     pause,
     resume,

--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -30,6 +30,16 @@ interface UseAudioBookOptions {
  * the decoded end (chapter marks routinely do) still lands inside the media.
  * Rejects rather than waiting forever when the media never becomes seekable.
  */
+function withTimeout<T>(work: Promise<T>, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), NARRATION_LOAD_TIMEOUT_MS);
+    work.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); }
+    );
+  });
+}
+
 function seekTo(audio: HTMLAudioElement, time: number): Promise<void> {
   const applySeek = () => {
     audio.currentTime = isFinite(audio.duration) ? Math.min(time, audio.duration) : time;
@@ -107,6 +117,7 @@ export function useAudioBook({
   const [index, setIndex] = useState(-1);
   const [cursor, setCursor] = useState(-1);
   const [narrationError, setNarrationError] = useState<string | null>(null);
+  const [narrationDisabled, setNarrationDisabled] = useState(false);
   const [speed, setSpeedState] = useState<number>(TTS_CONFIG.DEFAULT_SPEED);
   const [voiceGender, setVoiceGenderState] = useState<TTSVoiceGender>(TTS_CONFIG.DEFAULT_VOICE_GENDER);
 
@@ -120,6 +131,8 @@ export function useAudioBook({
 
   const narrationAudioRef = useRef<HTMLAudioElement | null>(null);
   const narrationUrlRef = useRef<string | null>(null);
+  const narrationFailuresRef = useRef(0);
+  const narrationDisabledRef = useRef(false);
 
   const unitsRef = useRef(units);
   const narrationRef = useRef(narration);
@@ -131,11 +144,19 @@ export function useAudioBook({
   const playStepRef = useRef<(step: PlayStep, isAuto: boolean) => void>(() => {});
   const consecutiveFailuresRef = useRef(0);
 
-  // A manifest whose cues are all null covers nothing, so playback stays on TTS
-  // and the player must not claim otherwise.
-  const hasNarration = useMemo(() => Boolean(narration?.cues.some(Boolean)), [narration]);
+  // A manifest whose cues are all null covers nothing, and one we gave up on is
+  // no longer being played, so the player must not claim narration in either case.
+  const hasNarration = useMemo(
+    () => !narrationDisabled && Boolean(narration?.cues.some(Boolean)),
+    [narration, narrationDisabled]
+  );
 
-  useEffect(() => { narrationRef.current = narration; }, [narration]);
+  useEffect(() => {
+    narrationRef.current = narration;
+    narrationFailuresRef.current = 0;
+    narrationDisabledRef.current = false;
+    setNarrationDisabled(false);
+  }, [narration]);
   useEffect(() => { contentModeRef.current = contentMode; }, [contentMode]);
   useEffect(() => { speedRef.current = speed; }, [speed]);
   useEffect(() => { voiceRef.current = voiceGender; }, [voiceGender]);
@@ -229,7 +250,7 @@ export function useAudioBook({
   }, [releaseNarrationAudio]);
 
   const cueForStep = useCallback((step: PlayStep): NarrationCue | null => {
-    if (step.part !== 'main') return null;
+    if (step.part !== 'main' || narrationDisabledRef.current) return null;
     return narrationRef.current?.cues[step.index] ?? null;
   }, []);
 
@@ -283,7 +304,18 @@ export function useAudioBook({
       if (token !== playTokenRef.current) return;
       console.error('Narration playback failed:', error);
       isAutoRef.current = false;
-      setNarrationError('Audiobook recording could not be played');
+      // Retrying a broken recording forever would leave the book unplayable even
+      // though speech synthesis could read it, so give up on the recording and
+      // let the next play fall through to TTS.
+      narrationFailuresRef.current += 1;
+      const givingUp = narrationFailuresRef.current >= MAX_CONSECUTIVE_FAILURES;
+      if (givingUp) {
+        narrationDisabledRef.current = true;
+        setNarrationDisabled(true);
+      }
+      setNarrationError(givingUp
+        ? 'Audiobook recording unavailable, reading with speech synthesis'
+        : 'Audiobook recording could not be played');
       // A failed element keeps its error state and will not re-fire load events,
       // so leaving it cached would make every retry wait out the load timeout.
       releaseNarrationAudio();
@@ -328,12 +360,15 @@ export function useAudioBook({
         stopOnFailure(new Error(`Cue starts at ${cue.start}s, past the ${audio.duration}s recording`));
         return;
       }
-      await audio.play();
+      // Seeking into an unbuffered range can leave play() pending indefinitely on
+      // a hung range request, which would pin the player on its loading spinner.
+      await withTimeout(audio.play(), 'Narration audio did not start playing');
     } catch (error) {
       stopOnFailure(error);
       return;
     }
     if (token !== playTokenRef.current) return;
+    narrationFailuresRef.current = 0;
     setNarrationError(null);
     updateStatus('playing');
     consecutiveFailuresRef.current = 0;

--- a/app/hooks/useAudioBook.ts
+++ b/app/hooks/useAudioBook.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { STORAGE_KEYS, TTS_CONFIG, type TTSVoiceGender } from '@/lib/constants';
-import type { AudioBookContentMode, PlayableUnit } from '@/lib/types';
+import type { AudioBookContentMode, NarrationCue, NarrationManifest, PlayableUnit } from '@/lib/types';
 import { cleanTextForTTS } from '@/lib/utils/ttsTextCleaner';
 import { fetchTTS } from '@/lib/utils/ttsCache';
 
@@ -19,8 +19,23 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 interface UseAudioBookOptions {
   units: PlayableUnit[];
   contentMode: AudioBookContentMode;
+  narration?: NarrationManifest | null;
   onEnd?: () => void;
   getStartIndex?: () => number;
+}
+
+function seekTo(audio: HTMLAudioElement, time: number): Promise<void> {
+  if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) {
+    audio.currentTime = time;
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    audio.addEventListener('loadedmetadata', () => {
+      audio.currentTime = time;
+      resolve();
+    }, { once: true });
+    audio.addEventListener('error', () => reject(new Error('Narration audio failed to load')), { once: true });
+  });
 }
 
 function partText(unit: PlayableUnit, part: PlayPart): string {
@@ -63,6 +78,7 @@ function stepAfter(units: PlayableUnit[], step: PlayStep, mode: AudioBookContent
 export function useAudioBook({
   units,
   contentMode,
+  narration,
   onEnd,
   getStartIndex,
 }: UseAudioBookOptions) {
@@ -80,7 +96,11 @@ export function useAudioBook({
   const phaseRef = useRef<PlayPart>('main');
   const statusRef = useRef<AudioBookStatus>('idle');
 
+  const narrationAudioRef = useRef<HTMLAudioElement | null>(null);
+  const narrationUrlRef = useRef<string | null>(null);
+
   const unitsRef = useRef(units);
+  const narrationRef = useRef(narration);
   const contentModeRef = useRef(contentMode);
   const speedRef = useRef(speed);
   const voiceRef = useRef(voiceGender);
@@ -89,6 +109,22 @@ export function useAudioBook({
   const playStepRef = useRef<(step: PlayStep, isAuto: boolean) => void>(() => {});
   const consecutiveFailuresRef = useRef(0);
 
+  const releaseNarrationAudio = useCallback(() => {
+    const audio = narrationAudioRef.current;
+    if (!audio) return;
+    if (audioRef.current === audio) audioRef.current = null;
+    audio.ontimeupdate = null;
+    audio.onerror = null;
+    audio.pause();
+    audio.src = '';
+    narrationAudioRef.current = null;
+    narrationUrlRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    narrationRef.current = narration;
+    if (narration?.audioUrl !== narrationUrlRef.current) releaseNarrationAudio();
+  }, [narration, releaseNarrationAudio]);
   useEffect(() => { contentModeRef.current = contentMode; }, [contentMode]);
   useEffect(() => { speedRef.current = speed; }, [speed]);
   useEffect(() => { voiceRef.current = voiceGender; }, [voiceGender]);
@@ -136,18 +172,39 @@ export function useAudioBook({
     if (!audio) return;
     audio.onended = null;
     audio.onerror = null;
+    audio.ontimeupdate = null;
     audio.pause();
-    audio.src = '';
+    // The narration element is shared by every unit, so clearing its src here
+    // would re-download the whole recording on each sentence.
+    if (audio !== narrationAudioRef.current) audio.src = '';
     audioRef.current = null;
+  }, []);
+
+  const acquireNarrationAudio = useCallback((audioUrl: string) => {
+    const existing = narrationAudioRef.current;
+    if (existing && narrationUrlRef.current === audioUrl) return existing;
+    releaseNarrationAudio();
+    const audio = new Audio(audioUrl);
+    audio.preload = 'auto';
+    audio.preservesPitch = true;
+    narrationAudioRef.current = audio;
+    narrationUrlRef.current = audioUrl;
+    return audio;
+  }, [releaseNarrationAudio]);
+
+  const cueForStep = useCallback((step: PlayStep): NarrationCue | null => {
+    if (step.part !== 'main') return null;
+    return narrationRef.current?.cues[step.index] ?? null;
   }, []);
 
   const prefetch = useCallback((step: PlayStep) => {
     const next = stepAfter(unitsRef.current, step, contentModeRef.current);
     if (!next) return;
+    if (cueForStep(next)) return;
     const unit = unitsRef.current[next.index];
     const text = next.part === 'sub' ? unit.sub : unit.main;
     fetchTTS({ text: text ?? '', speed: 1, voiceGender: voiceRef.current }).catch(() => {});
-  }, []);
+  }, [cueForStep]);
 
   const advanceAfter = useCallback((token: number) => {
     if (token !== playTokenRef.current) return;
@@ -183,6 +240,47 @@ export function useAudioBook({
     updateStatus('idle');
   }, [advanceAfter, updateStatus]);
 
+  // A narration failure is a whole-recording problem rather than a bad clip, so
+  // it stops playback instead of skipping ahead like the TTS path does.
+  const playNarration = useCallback(async (cue: NarrationCue, token: number) => {
+    const manifest = narrationRef.current;
+    if (!manifest) return;
+
+    const stopOnFailure = (error: unknown) => {
+      if (token !== playTokenRef.current) return;
+      console.error('Narration playback failed:', error);
+      isAutoRef.current = false;
+      updateStatus('idle');
+    };
+
+    detachAudio();
+    const audio = acquireNarrationAudio(manifest.audioUrl);
+    audio.playbackRate = speedRef.current;
+    // timeupdate only fires a few times per second, but every cue ends where the
+    // narrator pauses, so the overshoot lands in silence rather than the next line.
+    audio.ontimeupdate = () => {
+      if (audio.currentTime < cue.end) return;
+      audio.ontimeupdate = null;
+      audio.pause();
+      advanceAfter(token);
+    };
+    audio.onerror = () => stopOnFailure(audio.error);
+    audioRef.current = audio;
+
+    try {
+      await seekTo(audio, cue.start);
+      if (token !== playTokenRef.current) return;
+      await audio.play();
+    } catch (error) {
+      stopOnFailure(error);
+      return;
+    }
+    if (token !== playTokenRef.current) return;
+    updateStatus('playing');
+    consecutiveFailuresRef.current = 0;
+    clearStartCursor();
+  }, [acquireNarrationAudio, advanceAfter, clearStartCursor, detachAudio, updateStatus]);
+
   const playStep = useCallback(async (step: PlayStep, isAuto: boolean) => {
     const units2 = unitsRef.current;
     if (step.index < 0 || step.index >= units2.length) return;
@@ -192,6 +290,12 @@ export function useAudioBook({
     phaseRef.current = step.part;
     updateIndex(step.index);
     updateStatus('loading');
+
+    const cue = cueForStep(step);
+    if (cue) {
+      await playNarration(cue, token);
+      return;
+    }
 
     const unit = units2[step.index];
     const text = step.part === 'sub' ? unit.sub : unit.main;
@@ -238,7 +342,7 @@ export function useAudioBook({
     consecutiveFailuresRef.current = 0;
     clearStartCursor();
     prefetch(step);
-  }, [advanceAfter, clearStartCursor, detachAudio, prefetch, skipOrEndOnFailure, updateIndex, updateStatus]);
+  }, [advanceAfter, clearStartCursor, cueForStep, detachAudio, playNarration, prefetch, skipOrEndOnFailure, updateIndex, updateStatus]);
 
   useEffect(() => { playStepRef.current = playStep; }, [playStep]);
 
@@ -350,8 +454,9 @@ export function useAudioBook({
     return () => {
       playTokenRef.current++;
       detachAudio();
+      releaseNarrationAudio();
     };
-  }, [detachAudio]);
+  }, [detachAudio, releaseNarrationAudio]);
 
   return {
     status,
@@ -359,6 +464,7 @@ export function useAudioBook({
     cursor,
     total: units.length,
     speed,
+    hasNarration: Boolean(narration),
     togglePlayPause,
     pause,
     resume,

--- a/app/hooks/useBookMetadata.ts
+++ b/app/hooks/useBookMetadata.ts
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { bookAssetPath } from '@/lib/utils/bookAssetPath';
 import type { BookMetadata, ImageMap } from '@/lib/types';
 
 interface UseBookMetadataResult {
@@ -36,21 +37,7 @@ export function useBookMetadata(
       setError(null);
 
       try {
-        // For rephrase files (ending with -rephrase or -rephrase-furigana), use the base book name for metadata
-        // e.g., "book-rephrase" -> "book", "book-rephrase-furigana" -> "book"
-        const isRephraseFile = /-rephrase(-furigana)?$/.test(fileName);
-        const baseFileName = isRephraseFile
-          ? fileName.replace(/-rephrase(-furigana)?$/, '')
-          : fileName;
-
-        // Construct JSON file path
-        // For rephrase files in nested directories (e.g., bookv2-furigana/book-name/),
-        // the JSON is in the same directory: /{directory}/{baseFileName}.json
-        // For regular files, it's: /{directory}/{fileName}/{fileName}.json
-        const jsonPath = isRephraseFile
-          ? `/${directory}/${baseFileName}.json`  // Rephrase: JSON is sibling to rephrase file
-          : `/${directory}/${baseFileName}/${baseFileName}.json`;  // Original: JSON is in book subfolder
-        const response = await fetch(jsonPath);
+        const response = await fetch(bookAssetPath(directory, fileName, '.json'));
 
         if (!response.ok) {
           // If JSON doesn't exist, silently fail (not all books have metadata)

--- a/app/hooks/useNarration.ts
+++ b/app/hooks/useNarration.ts
@@ -1,8 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { bookAssetPath } from '@/lib/utils/bookAssetPath';
+import { bookVariantAssetPath } from '@/lib/utils/bookAssetPath';
 import type { NarrationCue, NarrationManifest } from '@/lib/types';
+
+export interface NarrationLoad {
+  manifest: NarrationManifest | null;
+  error: string | null;
+}
+
+const ABSENT: NarrationLoad = { manifest: null, error: null };
 
 function parseCue(value: unknown): NarrationCue | null {
   if (!value || typeof value !== 'object') return null;
@@ -34,7 +41,7 @@ function parseManifest(value: unknown, url: string): NarrationManifest | null {
   // cues is what gets indexed by unit, so a short array would quietly drop the
   // tail of the book even though unitCount looked right.
   if (cues.length !== unitCount) {
-    console.error(`Narration manifest has ${cues.length} cues for ${unitCount} units: ${url}`);
+    console.error(`Narration manifest declares ${unitCount} units but has ${cues.length} cues: ${url}`);
     return null;
   }
 
@@ -51,55 +58,64 @@ function parseManifest(value: unknown, url: string): NarrationManifest | null {
 }
 
 /**
- * Loads the narration manifest that pairs a book with its audiobook recording.
+ * Loads the narration recording paired with the text variant being read.
  *
- * Returns null whenever the book has no usable recording, which keeps playback on
- * TTS. `unitCount` must match the reader's own unit count or the manifest is
- * rejected: cues are positional, so a re-processed book would otherwise play the
- * wrong audio for every line after the first inserted or removed paragraph.
+ * Cues are positional, so the manifest is only usable when the book still starts
+ * with the units it was built from. A shorter book is accepted because it is a
+ * prefix -- that is how the guest preview arrives -- but a longer one means the
+ * text was re-processed and every cue after the change would play the wrong line.
  */
 export function useNarration(
   fileName: string | null,
   directory: string | null,
   unitCount: number
-): NarrationManifest | null {
-  const [manifest, setManifest] = useState<NarrationManifest | null>(null);
+): NarrationLoad {
+  const [load, setLoad] = useState<NarrationLoad>(ABSENT);
 
   useEffect(() => {
     // Drop the previous book's manifest before anything else. Cues are positional,
     // so serving book A's cues against book B's units for even one render is the
     // exact mismatch unitCount exists to prevent.
-    setManifest(null);
+    setLoad(ABSENT);
     if (!fileName || !directory || unitCount <= 0) return;
 
     const controller = new AbortController();
-    const url = bookAssetPath(directory, fileName, '.narration.json');
+    const url = bookVariantAssetPath(directory, fileName, '.narration.json');
+
+    const fail = (message: string, detail: string) => {
+      console.error(`${detail}: ${url}`);
+      setLoad({ manifest: null, error: message });
+    };
 
     const loadManifest = async () => {
       try {
         const response = await fetch(url, { signal: controller.signal });
         if (controller.signal.aborted) return;
         if (!response.ok) {
-          // 404 just means this book has no recording; anything else is a fault
-          // worth seeing, since both downgrade silently to TTS.
-          if (response.status !== 404) {
-            console.error(`Narration manifest request failed (${response.status}): ${url}`);
-          }
+          // 404 just means this variant has no recording, which is the normal case.
+          if (response.status === 404) return;
+          fail('Audiobook recording could not be loaded', `Narration manifest request failed (${response.status})`);
           return;
         }
 
         const parsed = parseManifest(await response.json(), url);
         if (controller.signal.aborted) return;
-        if (parsed && parsed.unitCount !== unitCount) {
-          console.error(
-            `Narration manifest is stale: built for ${parsed.unitCount} units, book now has ${unitCount}. Rebuild it with scripts/audio/build-narration.ts.`
+        if (!parsed) {
+          fail('Audiobook recording is unusable', 'Narration manifest failed validation');
+          return;
+        }
+        if (parsed.unitCount < unitCount) {
+          fail(
+            'Audiobook recording is out of date',
+            `Narration manifest is stale: built for ${parsed.unitCount} units, this text now has ${unitCount}. Rebuild it with scripts/audio/build-narration.ts`
           );
           return;
         }
-        setManifest(parsed);
+        setLoad({ manifest: parsed, error: null });
       } catch (error) {
         if (controller.signal.aborted) return;
         console.error(`Failed to load narration manifest: ${url}`, error);
+        setLoad({ manifest: null, error: 'Audiobook recording could not be loaded' });
       }
     };
 
@@ -107,5 +123,5 @@ export function useNarration(
     return () => controller.abort();
   }, [fileName, directory, unitCount]);
 
-  return manifest;
+  return load;
 }

--- a/app/hooks/useNarration.ts
+++ b/app/hooks/useNarration.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { bookAssetPath } from '@/lib/utils/bookAssetPath';
+import type { NarrationCue, NarrationManifest } from '@/lib/types';
+
+function parseCue(value: unknown): NarrationCue | null {
+  if (!value || typeof value !== 'object') return null;
+  const { start, end } = value as Record<string, unknown>;
+  if (typeof start !== 'number' || typeof end !== 'number') return null;
+  if (!isFinite(start) || !isFinite(end) || end <= start) return null;
+  return { start, end };
+}
+
+function parseManifest(value: unknown): NarrationManifest | null {
+  if (!value || typeof value !== 'object') return null;
+  const { audioUrl, cues } = value as Record<string, unknown>;
+  if (typeof audioUrl !== 'string' || !audioUrl) return null;
+  if (!Array.isArray(cues)) return null;
+  return { audioUrl, cues: cues.map(parseCue) };
+}
+
+/**
+ * Loads the narration manifest that pairs a book with its audiobook recording.
+ * Returns null whenever the book has no recording, which keeps playback on TTS.
+ */
+export function useNarration(fileName: string | null, directory: string | null): NarrationManifest | null {
+  const [manifest, setManifest] = useState<NarrationManifest | null>(null);
+
+  useEffect(() => {
+    if (!fileName || !directory) {
+      setManifest(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const loadManifest = async () => {
+      try {
+        const response = await fetch(bookAssetPath(directory, fileName, '.narration.json'), {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          setManifest(null);
+          return;
+        }
+        setManifest(parseManifest(await response.json()));
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Failed to load narration manifest:', error);
+        setManifest(null);
+      }
+    };
+
+    loadManifest();
+    return () => controller.abort();
+  }, [fileName, directory]);
+
+  return manifest;
+}

--- a/app/hooks/useNarration.ts
+++ b/app/hooks/useNarration.ts
@@ -97,6 +97,10 @@ export function useNarration(
           fail('Audiobook recording could not be loaded', `Narration manifest request failed (${response.status})`);
           return;
         }
+        // A guest is redirected to the login page, and a CDN can answer a missing
+        // object with an HTML error body -- both arrive as a perfectly ok
+        // response. Neither is a fault worth showing, so treat them as absent.
+        if (!response.headers.get('content-type')?.includes('json')) return;
 
         const parsed = parseManifest(await response.json(), url);
         if (controller.signal.aborted) return;

--- a/app/hooks/useNarration.ts
+++ b/app/hooks/useNarration.ts
@@ -8,53 +8,99 @@ function parseCue(value: unknown): NarrationCue | null {
   if (!value || typeof value !== 'object') return null;
   const { start, end } = value as Record<string, unknown>;
   if (typeof start !== 'number' || typeof end !== 'number') return null;
-  if (!isFinite(start) || !isFinite(end) || end <= start) return null;
+  if (!isFinite(start) || !isFinite(end)) return null;
+  if (start < 0 || end <= start) return null;
   return { start, end };
 }
 
-function parseManifest(value: unknown): NarrationManifest | null {
-  if (!value || typeof value !== 'object') return null;
-  const { audioUrl, cues } = value as Record<string, unknown>;
-  if (typeof audioUrl !== 'string' || !audioUrl) return null;
-  if (!Array.isArray(cues)) return null;
-  return { audioUrl, cues: cues.map(parseCue) };
+function parseManifest(value: unknown, url: string): NarrationManifest | null {
+  if (!value || typeof value !== 'object') {
+    console.error(`Narration manifest is not an object: ${url}`);
+    return null;
+  }
+  const { audioUrl, unitCount, cues } = value as Record<string, unknown>;
+  if (typeof audioUrl !== 'string' || !audioUrl) {
+    console.error(`Narration manifest has no audioUrl: ${url}`);
+    return null;
+  }
+  if (typeof unitCount !== 'number' || !Number.isInteger(unitCount) || unitCount <= 0) {
+    console.error(`Narration manifest has no usable unitCount: ${url}`);
+    return null;
+  }
+  if (!Array.isArray(cues)) {
+    console.error(`Narration manifest has no cues array: ${url}`);
+    return null;
+  }
+
+  const parsed = cues.map(parseCue);
+  const dropped = parsed.filter((cue, index) => !cue && cues[index] !== null).length;
+  if (dropped > 0) {
+    console.error(`Narration manifest has ${dropped} malformed cues, those units fall back to TTS: ${url}`);
+  }
+  if (!parsed.some(Boolean)) {
+    console.error(`Narration manifest covers no units: ${url}`);
+    return null;
+  }
+  return { audioUrl, unitCount, cues: parsed };
 }
 
 /**
  * Loads the narration manifest that pairs a book with its audiobook recording.
- * Returns null whenever the book has no recording, which keeps playback on TTS.
+ *
+ * Returns null whenever the book has no usable recording, which keeps playback on
+ * TTS. `unitCount` must match the reader's own unit count or the manifest is
+ * rejected: cues are positional, so a re-processed book would otherwise play the
+ * wrong audio for every line after the first inserted or removed paragraph.
  */
-export function useNarration(fileName: string | null, directory: string | null): NarrationManifest | null {
+export function useNarration(
+  fileName: string | null,
+  directory: string | null,
+  unitCount: number
+): NarrationManifest | null {
   const [manifest, setManifest] = useState<NarrationManifest | null>(null);
 
   useEffect(() => {
-    if (!fileName || !directory) {
+    if (!fileName || !directory || unitCount <= 0) {
       setManifest(null);
       return;
     }
 
     const controller = new AbortController();
+    const url = bookAssetPath(directory, fileName, '.narration.json');
 
     const loadManifest = async () => {
       try {
-        const response = await fetch(bookAssetPath(directory, fileName, '.narration.json'), {
-          signal: controller.signal,
-        });
+        const response = await fetch(url, { signal: controller.signal });
         if (!response.ok) {
+          // 404 just means this book has no recording; anything else is a fault
+          // worth seeing, since both downgrade silently to TTS.
+          if (response.status !== 404) {
+            console.error(`Narration manifest request failed (${response.status}): ${url}`);
+          }
           setManifest(null);
           return;
         }
-        setManifest(parseManifest(await response.json()));
+
+        const parsed = parseManifest(await response.json(), url);
+        if (controller.signal.aborted) return;
+        if (parsed && parsed.unitCount !== unitCount) {
+          console.error(
+            `Narration manifest is stale: built for ${parsed.unitCount} units, book now has ${unitCount}. Rebuild it with scripts/audio/build-narration.ts.`
+          );
+          setManifest(null);
+          return;
+        }
+        setManifest(parsed);
       } catch (error) {
         if (controller.signal.aborted) return;
-        console.error('Failed to load narration manifest:', error);
+        console.error(`Failed to load narration manifest: ${url}`, error);
         setManifest(null);
       }
     };
 
     loadManifest();
     return () => controller.abort();
-  }, [fileName, directory]);
+  }, [fileName, directory, unitCount]);
 
   return manifest;
 }

--- a/app/hooks/useNarration.ts
+++ b/app/hooks/useNarration.ts
@@ -31,6 +31,12 @@ function parseManifest(value: unknown, url: string): NarrationManifest | null {
     console.error(`Narration manifest has no cues array: ${url}`);
     return null;
   }
+  // cues is what gets indexed by unit, so a short array would quietly drop the
+  // tail of the book even though unitCount looked right.
+  if (cues.length !== unitCount) {
+    console.error(`Narration manifest has ${cues.length} cues for ${unitCount} units: ${url}`);
+    return null;
+  }
 
   const parsed = cues.map(parseCue);
   const dropped = parsed.filter((cue, index) => !cue && cues[index] !== null).length;
@@ -60,10 +66,11 @@ export function useNarration(
   const [manifest, setManifest] = useState<NarrationManifest | null>(null);
 
   useEffect(() => {
-    if (!fileName || !directory || unitCount <= 0) {
-      setManifest(null);
-      return;
-    }
+    // Drop the previous book's manifest before anything else. Cues are positional,
+    // so serving book A's cues against book B's units for even one render is the
+    // exact mismatch unitCount exists to prevent.
+    setManifest(null);
+    if (!fileName || !directory || unitCount <= 0) return;
 
     const controller = new AbortController();
     const url = bookAssetPath(directory, fileName, '.narration.json');
@@ -71,13 +78,13 @@ export function useNarration(
     const loadManifest = async () => {
       try {
         const response = await fetch(url, { signal: controller.signal });
+        if (controller.signal.aborted) return;
         if (!response.ok) {
           // 404 just means this book has no recording; anything else is a fault
           // worth seeing, since both downgrade silently to TTS.
           if (response.status !== 404) {
             console.error(`Narration manifest request failed (${response.status}): ${url}`);
           }
-          setManifest(null);
           return;
         }
 
@@ -87,14 +94,12 @@ export function useNarration(
           console.error(
             `Narration manifest is stale: built for ${parsed.unitCount} units, book now has ${unitCount}. Rebuild it with scripts/audio/build-narration.ts.`
           );
-          setManifest(null);
           return;
         }
         setManifest(parsed);
       } catch (error) {
         if (controller.signal.aborted) return;
         console.error(`Failed to load narration manifest: ${url}`, error);
-        setManifest(null);
       }
     };
 

--- a/app/read/components/AudioPlayerBar.tsx
+++ b/app/read/components/AudioPlayerBar.tsx
@@ -20,7 +20,7 @@ interface AudioPlayerBarProps {
   isDarkMode: boolean;
   keyboardMode: boolean;
   hasNarration: boolean;
-  narrationError: string | null;
+  playbackError: string | null;
   onTogglePlay: () => void;
   onPrev: () => void;
   onNext: () => void;
@@ -92,7 +92,7 @@ export default function AudioPlayerBar({
   isDarkMode,
   keyboardMode,
   hasNarration,
-  narrationError,
+  playbackError,
   onTogglePlay,
   onPrev,
   onNext,
@@ -253,7 +253,7 @@ export default function AudioPlayerBar({
           })}
         </div>
 
-        {narrationError ? (
+        {playbackError ? (
           <span
             role="status"
             style={{
@@ -265,7 +265,7 @@ export default function AudioPlayerBar({
               backgroundColor: '#FF3B30',
             }}
           >
-            {narrationError}
+            {playbackError}
           </span>
         ) : hasNarration && contentMode !== 'sub' && (
           <span

--- a/app/read/components/AudioPlayerBar.tsx
+++ b/app/read/components/AudioPlayerBar.tsx
@@ -20,6 +20,7 @@ interface AudioPlayerBarProps {
   isDarkMode: boolean;
   keyboardMode: boolean;
   hasNarration: boolean;
+  narrationError: string | null;
   onTogglePlay: () => void;
   onPrev: () => void;
   onNext: () => void;
@@ -91,6 +92,7 @@ export default function AudioPlayerBar({
   isDarkMode,
   keyboardMode,
   hasNarration,
+  narrationError,
   onTogglePlay,
   onPrev,
   onNext,
@@ -251,7 +253,21 @@ export default function AudioPlayerBar({
           })}
         </div>
 
-        {hasNarration && contentMode !== 'sub' && (
+        {narrationError ? (
+          <span
+            role="status"
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              padding: '4px 9px',
+              borderRadius: 7,
+              color: '#FFFFFF',
+              backgroundColor: '#FF3B30',
+            }}
+          >
+            {narrationError}
+          </span>
+        ) : hasNarration && contentMode !== 'sub' && (
           <span
             title="Playing the audiobook recording. Rephrased text still uses text-to-speech."
             style={{

--- a/app/read/components/AudioPlayerBar.tsx
+++ b/app/read/components/AudioPlayerBar.tsx
@@ -19,6 +19,7 @@ interface AudioPlayerBarProps {
   speed: number;
   isDarkMode: boolean;
   keyboardMode: boolean;
+  hasNarration: boolean;
   onTogglePlay: () => void;
   onPrev: () => void;
   onNext: () => void;
@@ -89,6 +90,7 @@ export default function AudioPlayerBar({
   speed,
   isDarkMode,
   keyboardMode,
+  hasNarration,
   onTogglePlay,
   onPrev,
   onNext,
@@ -248,6 +250,22 @@ export default function AudioPlayerBar({
             );
           })}
         </div>
+
+        {hasNarration && contentMode !== 'sub' && (
+          <span
+            title="Playing the audiobook recording. Rephrased text still uses text-to-speech."
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              padding: '4px 9px',
+              borderRadius: 7,
+              color: accent,
+              backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)',
+            }}
+          >
+            Narration
+          </span>
+        )}
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginLeft: 'auto' }}>
           <span style={{ fontSize: 13, color: subtle, fontVariantNumeric: 'tabular-nums', minWidth: 64, textAlign: 'right' }}>

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -313,6 +313,7 @@ function ReaderContent({
     total: audioTotal,
     speed: audioSpeed,
     hasNarration,
+    narrationError,
     togglePlayPause,
     next: audioNext,
     previous: audioPrev,
@@ -878,6 +879,7 @@ function ReaderContent({
           isDarkMode={isDarkMode}
           keyboardMode={keyboardMode}
           hasNarration={hasNarration}
+          narrationError={narrationError}
           onTogglePlay={togglePlayPause}
           onPrev={audioPrev}
           onNext={audioNext}

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -304,7 +304,7 @@ function ReaderContent({
     return bookmarkPageForIndex === currentPage ? bookmarkItemIndex : pageTop;
   }, [currentPage, bookmarkItemIndex]);
 
-  const narration = useNarration(fileNameParam, directoryParam);
+  const narration = useNarration(fileNameParam, directoryParam, totalItems);
 
   const {
     status: audioStatus,

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -182,6 +182,8 @@ function ReaderContent({
       return;
     }
 
+    const controller = new AbortController();
+
     const fetchData = async () => {
       setIsLoading(true);
       setError(null);
@@ -192,27 +194,33 @@ function ReaderContent({
 
       try {
         const [contentRes, bookmarkRes] = await Promise.all([
-          fetch(`${API_ROUTES.READ_TEXT}?fileName=${encodeURIComponent(fullFilePath)}`),
-          fetch(`${API_ROUTES.READ_BOOKMARK}?fileName=${encodeURIComponent(fullFilePath)}`),
+          fetch(`${API_ROUTES.READ_TEXT}?fileName=${encodeURIComponent(fullFilePath)}`, { signal: controller.signal }),
+          fetch(`${API_ROUTES.READ_BOOKMARK}?fileName=${encodeURIComponent(fullFilePath)}`, { signal: controller.signal }),
         ]);
 
         if (!contentRes.ok) throw new Error('Failed to load content');
 
         const contentData = await contentRes.json();
+        if (controller.signal.aborted) return;
         setContent(contentData.text || '');
 
         if (bookmarkRes.ok) {
           const bookmarkData = await bookmarkRes.json();
+          if (controller.signal.aborted) return;
           setBookmarkText(bookmarkData.text || '');
         }
       } catch (err) {
+        if (controller.signal.aborted) return;
         setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
-        setIsLoading(false);
+        if (!controller.signal.aborted) setIsLoading(false);
       }
     };
 
     fetchData();
+    // A late response from the book we just left would otherwise overwrite the
+    // new book's text, and narration would then be keyed on the wrong unit count.
+    return () => controller.abort();
   }, [fullFilePath, router]);
 
   const playableUnits = useMemo(() => buildPlayableUnits(content), [content]);
@@ -321,7 +329,7 @@ function ReaderContent({
     total: audioTotal,
     speed: audioSpeed,
     hasNarration,
-    narrationError,
+    playbackError,
     togglePlayPause,
     next: audioNext,
     previous: audioPrev,
@@ -887,7 +895,7 @@ function ReaderContent({
           isDarkMode={isDarkMode}
           keyboardMode={keyboardMode}
           hasNarration={hasNarration}
-          narrationError={narrationError ?? narrationLoadError}
+          playbackError={playbackError ?? narrationLoadError}
           onTogglePlay={togglePlayPause}
           onPrev={audioPrev}
           onNext={audioNext}

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -27,6 +27,7 @@ import { stripFurigana } from '@/lib/utils/furiganaParser';
 import { buildPlayableUnits } from '@/lib/utils/buildPlayableUnits';
 import { guestKeyHeaders, promptGuestKeyOnFailure } from '@/lib/guestKeys';
 import { useAudioBook } from '@/app/hooks/useAudioBook';
+import { useNarration } from '@/app/hooks/useNarration';
 import type { AudioBookContentMode } from '@/lib/types';
 
 const ExplanationSidebar = dynamic(
@@ -303,12 +304,15 @@ function ReaderContent({
     return bookmarkPageForIndex === currentPage ? bookmarkItemIndex : pageTop;
   }, [currentPage, bookmarkItemIndex]);
 
+  const narration = useNarration(fileNameParam, directoryParam);
+
   const {
     status: audioStatus,
     index: audioIndex,
     cursor: audioStartCursor,
     total: audioTotal,
     speed: audioSpeed,
+    hasNarration,
     togglePlayPause,
     next: audioNext,
     previous: audioPrev,
@@ -320,6 +324,7 @@ function ReaderContent({
   } = useAudioBook({
     units: playableUnits,
     contentMode,
+    narration,
     getStartIndex,
   });
 
@@ -872,6 +877,7 @@ function ReaderContent({
           speed={audioSpeed}
           isDarkMode={isDarkMode}
           keyboardMode={keyboardMode}
+          hasNarration={hasNarration}
           onTogglePlay={togglePlayPause}
           onPrev={audioPrev}
           onNext={audioNext}

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -185,6 +185,9 @@ function ReaderContent({
     const fetchData = async () => {
       setIsLoading(true);
       setError(null);
+      // Keeping the previous book's text would leave every derived value - unit
+      // count, page count, narration lookup - describing the book we just left.
+      setContent('');
 
       try {
         const [contentRes, bookmarkRes] = await Promise.all([

--- a/app/read/page.tsx
+++ b/app/read/page.tsx
@@ -188,6 +188,7 @@ function ReaderContent({
       // Keeping the previous book's text would leave every derived value - unit
       // count, page count, narration lookup - describing the book we just left.
       setContent('');
+      setBookmarkText('');
 
       try {
         const [contentRes, bookmarkRes] = await Promise.all([
@@ -307,7 +308,11 @@ function ReaderContent({
     return bookmarkPageForIndex === currentPage ? bookmarkItemIndex : pageTop;
   }, [currentPage, bookmarkItemIndex]);
 
-  const narration = useNarration(fileNameParam, directoryParam, totalItems);
+  const { manifest: narration, error: narrationLoadError } = useNarration(
+    fileNameParam,
+    directoryParam,
+    totalItems
+  );
 
   const {
     status: audioStatus,
@@ -882,7 +887,7 @@ function ReaderContent({
           isDarkMode={isDarkMode}
           keyboardMode={keyboardMode}
           hasNarration={hasNarration}
-          narrationError={narrationError}
+          narrationError={narrationError ?? narrationLoadError}
           onTogglePlay={togglePlayPause}
           onPrev={audioPrev}
           onNext={audioNext}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,8 +27,9 @@ export interface NarrationCue {
 // 朗読音源のマニフェスト。cues の添字は PlayableUnit.globalIndex と一致し、
 // 音源が対応していないユニットは null（TTSにフォールバックする）
 //
-// unitCount は生成時の本文のユニット数。本文を再生成して段落が1つでも増減すると
-// 以降の添字が全部ずれるため、読み込み時に照合して古いマニフェストを弾く。
+// unitCount は生成時の本文のユニット数。読み込み側は「本文がこれより長い」場合だけ
+// 弾く（段落が増えた ＝ 以降の添字が全部ずれる）。短い場合は先頭からの一部とみなして
+// 受け入れる（ゲストプレビューがこの形）。同じ長さの編集と段落削除は検出できない。
 export interface NarrationManifest {
   audioUrl: string;
   unitCount: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,8 +26,12 @@ export interface NarrationCue {
 
 // 朗読音源のマニフェスト。cues の添字は PlayableUnit.globalIndex と一致し、
 // 音源が対応していないユニットは null（TTSにフォールバックする）
+//
+// unitCount は生成時の本文のユニット数。本文を再生成して段落が1つでも増減すると
+// 以降の添字が全部ずれるため、読み込み時に照合して古いマニフェストを弾く。
 export interface NarrationManifest {
   audioUrl: string;
+  unitCount: number;
   cues: (NarrationCue | null)[];
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,19 @@ export interface PlayableUnit {
 // オーディオブックで読み上げる対象
 export type AudioBookContentMode = 'main' | 'sub' | 'both';
 
+// 朗読音源の再生区間（秒）
+export interface NarrationCue {
+  start: number;
+  end: number;
+}
+
+// 朗読音源のマニフェスト。cues の添字は PlayableUnit.globalIndex と一致し、
+// 音源が対応していないユニットは null（TTSにフォールバックする）
+export interface NarrationManifest {
+  audioUrl: string;
+  cues: (NarrationCue | null)[];
+}
+
 // 辞書の単語構造（漢字[読み・意味]）
 export interface DictionaryWord {
   kanji: string;

--- a/lib/utils/bookAssetPath.ts
+++ b/lib/utils/bookAssetPath.ts
@@ -3,8 +3,10 @@ const REPHRASE_SUFFIX_PATTERN = /-rephrase(-furigana)?$/;
 /**
  * Public URL of a book sidecar asset (metadata, narration, ...).
  *
- * Rephrase files live next to their book folder, so their sidecars are siblings
- * of the folder; original files live inside it. Both resolve to the same book.
+ * Both branches resolve to `/<...>/<book>/<book><extension>`; they differ only in
+ * where the book folder comes from. For a rephrase file the directory already
+ * points at it, so the sidecar sits beside the text file. For an original file
+ * the directory is the parent and the book name doubles as the subfolder.
  */
 export function bookAssetPath(directory: string, fileName: string, extension: string): string {
   const isRephraseFile = REPHRASE_SUFFIX_PATTERN.test(fileName);

--- a/lib/utils/bookAssetPath.ts
+++ b/lib/utils/bookAssetPath.ts
@@ -1,0 +1,15 @@
+const REPHRASE_SUFFIX_PATTERN = /-rephrase(-furigana)?$/;
+
+/**
+ * Public URL of a book sidecar asset (metadata, narration, ...).
+ *
+ * Rephrase files live next to their book folder, so their sidecars are siblings
+ * of the folder; original files live inside it. Both resolve to the same book.
+ */
+export function bookAssetPath(directory: string, fileName: string, extension: string): string {
+  const isRephraseFile = REPHRASE_SUFFIX_PATTERN.test(fileName);
+  const baseFileName = fileName.replace(REPHRASE_SUFFIX_PATTERN, '');
+  return isRephraseFile
+    ? `/${directory}/${baseFileName}${extension}`
+    : `/${directory}/${baseFileName}/${baseFileName}${extension}`;
+}

--- a/lib/utils/bookAssetPath.ts
+++ b/lib/utils/bookAssetPath.ts
@@ -1,17 +1,27 @@
 const REPHRASE_SUFFIX_PATTERN = /-rephrase(-furigana)?$/;
 
 /**
- * Public URL of a book sidecar asset (metadata, narration, ...).
- *
- * Both branches resolve to `/<...>/<book>/<book><extension>`; they differ only in
- * where the book folder comes from. For a rephrase file the directory already
- * points at it, so the sidecar sits beside the text file. For an original file
- * the directory is the parent and the book name doubles as the subfolder.
+ * Folder holding a book's text and sidecars. For a rephrase file the directory
+ * already points at it; for an original file the directory is the parent and the
+ * book name doubles as the subfolder.
  */
+function bookFolder(directory: string, fileName: string): string {
+  return REPHRASE_SUFFIX_PATTERN.test(fileName) ? directory : `${directory}/${fileName}`;
+}
+
+/** Public URL of a per-book sidecar, shared by every text variant of that book. */
 export function bookAssetPath(directory: string, fileName: string, extension: string): string {
-  const isRephraseFile = REPHRASE_SUFFIX_PATTERN.test(fileName);
   const baseFileName = fileName.replace(REPHRASE_SUFFIX_PATTERN, '');
-  return isRephraseFile
-    ? `/${directory}/${baseFileName}${extension}`
-    : `/${directory}/${baseFileName}/${baseFileName}${extension}`;
+  return `/${bookFolder(directory, fileName)}/${baseFileName}${extension}`;
+}
+
+/**
+ * Public URL of a sidecar belonging to one text variant rather than the book.
+ *
+ * Variants differ in how the reader splits them into units, so anything indexed
+ * by unit has to be per-variant: a book-wide path would hand the plain text the
+ * rephrase build's cues, which line up with neither.
+ */
+export function bookVariantAssetPath(directory: string, fileName: string, extension: string): string {
+  return `/${bookFolder(directory, fileName)}/${fileName}${extension}`;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,6 +34,10 @@ function isGuestAllowed(request: NextRequest): boolean {
   // cap; images are already excluded from the matcher, so they still render.
   const decodedPath = decodePath(path);
   if (!decodedPath.endsWith('.json')) return false;
+  // The narration manifest is a .json sibling, but it carries the URL of the
+  // complete recording plus cue times for the whole book, so letting it ride this
+  // allowance would hand guests the audio the preview cap exists to withhold.
+  if (decodedPath.endsWith('.narration.json')) return false;
   return PUBLIC_BOOKS.some((book) => decodedPath.startsWith(`/${book.directory}/`));
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -33,11 +33,14 @@ function isGuestAllowed(request: NextRequest): boolean {
   // keeps the full-text .txt sibling from riding along and bypassing the preview
   // cap; images are already excluded from the matcher, so they still render.
   const decodedPath = decodePath(path);
-  if (!decodedPath.endsWith('.json')) return false;
+  // Compared case-insensitively because a case-insensitive filesystem would serve
+  // .NARRATION.json from the same file an exact-case check would have denied.
+  const suffix = decodedPath.toLowerCase();
+  if (!suffix.endsWith('.json')) return false;
   // The narration manifest is a .json sibling, but it carries the URL of the
   // complete recording plus cue times for the whole book, so letting it ride this
   // allowance would hand guests the audio the preview cap exists to withhold.
-  if (decodedPath.endsWith('.narration.json')) return false;
+  if (suffix.endsWith('.narration.json')) return false;
   return PUBLIC_BOOKS.some((book) => decodedPath.startsWith(`/${book.directory}/`));
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,6 +100,12 @@ Notes:
   that has grown; shorter text is accepted as a prefix because that is how the
   guest preview arrives. A same-length edit and a deleted paragraph both slip
   through, so rebuild the manifest whenever you re-process a book
+- Do not publish a manifest for a book that is in the guest preview allowlist.
+  `middleware.ts` denies `.narration.json` to signed-out visitors, but that only
+  covers requests the server function sees: under SST, `public/` is uploaded to S3
+  and CloudFront answers those paths directly, so middleware never runs. Today
+  `public/bookv2-furigana/*` is gitignored and CI deploys from a plain checkout,
+  so nothing lands there — the middleware rule is defence in depth, not the gate
 - Requires `ffmpeg` and `ffprobe` on PATH, and the container must have chapter marks
 - Audio is not served from `public/`. Host it separately and pass its URL: the
   recording is far too large for the Lambda bundle. Re-encode to mono and add

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,6 +61,37 @@ python scripts/epub-to-text-furigana.py path/to/book.epub
 
 For detailed documentation on the EPUB to Text converter, see [README-epub-converter.md](./README-epub-converter.md).
 
+## Audiobook Narration (`audio/`)
+
+Lets the reader's play button use a real narration instead of Google TTS. Needs the
+recording plus a transcript of it — not the ebook text, it must match what is spoken.
+
+```bash
+# 1. Align transcript to audio -> .srt (for eyeballing) + .timings.json
+python scripts/audio/align-transcript.py "book.m4b" "book.txt"
+
+# 2. Map those cues onto reader units -> the manifest the reader fetches
+npx tsx scripts/audio/build-narration.ts \
+  --timings "book.timings.json" \
+  --text "public/bookv2-furigana/<book>/<book>-rephrase-furigana.txt" \
+  --audio-url "https://<cdn>/<book>.m4a" \
+  --out "public/bookv2-furigana/<book>.narration.json"
+```
+
+The aligner uses no ASR. Container chapter marks are exact anchors, ffmpeg
+`silencedetect` supplies candidate boundaries, and MeCab mora counts predict
+relative duration within a chapter; a DP then picks the boundaries chapter by
+chapter. It prints a mora/s spread — a tight p05..p95 means a good alignment.
+
+Notes:
+
+- Requires `ffmpeg` and `ffprobe` on PATH, and the container must have chapter marks
+- Audio is not served from `public/`. Host it separately and pass its URL: the
+  recording is far too large for the Lambda bundle. Re-encode to mono and add
+  `-movflags +faststart` so the browser can seek with range requests
+- Manifest cue indices are `PlayableUnit.globalIndex`; `null` falls back to TTS
+- Rephrased text has no recording, so `sub` playback stays on TTS
+
 ## Virtual Environment Notes
 
 **Important:** The `venv/` directory should NOT be committed to git. It's already in `.gitignore`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,16 +75,27 @@ npx tsx scripts/audio/build-narration.ts \
   --timings "book.timings.json" \
   --text "public/bookv2-furigana/<book>/<book>-rephrase-furigana.txt" \
   --audio-url "https://<cdn>/<book>.m4a" \
-  --out "public/bookv2-furigana/<book>.narration.json"
+  --out "public/bookv2-furigana/<book>/<book>.narration.json"
 ```
 
 The aligner uses no ASR. Container chapter marks are exact anchors, ffmpeg
 `silencedetect` supplies candidate boundaries, and MeCab mora counts predict
 relative duration within a chapter; a DP then picks the boundaries chapter by
 chapter. It prints a mora/s spread — a tight p05..p95 means a good alignment.
+It refuses to write anything when a chapter falls back to proportional timings
+or a chapter title matches too weakly, since both produce plausible-looking cues
+that land mid-speech.
 
 Notes:
 
+- The `--out` path must sit **inside** the book folder and be named after the book,
+  next to `<book>.json`. That is where the reader looks; one level up is a silent
+  404 that leaves playback on TTS with no error anywhere
+- `--text` must be the same revision that was synced to the `text_entries` table.
+  The reader builds its units from Postgres, not from `public/*.txt`, and cues are
+  positional — if the two have drifted by a paragraph, every later line plays the
+  wrong audio. The builder stores a `unitCount` so the reader can reject a stale
+  manifest, but it cannot detect a same-length edit
 - Requires `ffmpeg` and `ffprobe` on PATH, and the container must have chapter marks
 - Audio is not served from `public/`. Host it separately and pass its URL: the
   recording is far too large for the Lambda bundle. Re-encode to mono and add

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,7 +75,7 @@ npx tsx scripts/audio/build-narration.ts \
   --timings "book.timings.json" \
   --text "public/bookv2-furigana/<book>/<book>-rephrase-furigana.txt" \
   --audio-url "https://<cdn>/<book>.m4a" \
-  --out "public/bookv2-furigana/<book>/<book>.narration.json"
+  --out "public/bookv2-furigana/<book>/<book>-rephrase-furigana.narration.json"
 ```
 
 The aligner uses no ASR. Container chapter marks are exact anchors, ffmpeg
@@ -88,9 +88,11 @@ that land mid-speech.
 
 Notes:
 
-- The `--out` path must sit **inside** the book folder and be named after the book,
-  next to `<book>.json`. That is where the reader looks; one level up is a silent
-  404 that leaves playback on TTS with no error anywhere
+- The `--out` path must sit **inside** the book folder and be named after the
+  **text file** it was built from, not the book. Each text variant splits into
+  different units, so each needs its own manifest; the plain variant would be
+  `<book>/<book>.narration.json`. Anywhere else is a silent 404 that leaves
+  playback on TTS with no error anywhere
 - `--text` must be the same revision that was synced to the `text_entries` table.
   The reader builds its units from Postgres, not from `public/*.txt`, and cues are
   positional — if the two have drifted by a paragraph, every later line plays the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,8 +96,10 @@ Notes:
 - `--text` must be the same revision that was synced to the `text_entries` table.
   The reader builds its units from Postgres, not from `public/*.txt`, and cues are
   positional — if the two have drifted by a paragraph, every later line plays the
-  wrong audio. The builder stores a `unitCount` so the reader can reject a stale
-  manifest, but it cannot detect a same-length edit
+  wrong audio. The builder stores a `unitCount`, but the reader only rejects text
+  that has grown; shorter text is accepted as a prefix because that is how the
+  guest preview arrives. A same-length edit and a deleted paragraph both slip
+  through, so rebuild the manifest whenever you re-process a book
 - Requires `ffmpeg` and `ffprobe` on PATH, and the container must have chapter marks
 - Audio is not served from `public/`. Host it separately and pass its URL: the
   recording is far too large for the Lambda bundle. Re-encode to mono and add

--- a/scripts/audio/align-transcript.py
+++ b/scripts/audio/align-transcript.py
@@ -25,7 +25,9 @@ COMMA_MORA_EQUIV = 2.5
 SHORT_PAUSE_SEC = 0.75
 PAUSE_PENALTY_WEIGHT = 4.0
 BAND_MIN_SEC = 8.0
+BAND_MAX_SEC = 45.0
 BAND_SPAN_RATIO = 0.3
+MIN_TITLE_SCORE = 0.55
 TITLE_MATCH_SPANS = (1, 2, 3)
 TITLE_SEARCH_WINDOW = 90
 SPOKEN_FORMS = {"content": "コンテンツ"}
@@ -103,11 +105,17 @@ def normalize(text: str) -> str:
     return "".join(ch for ch in folded if ch not in DROPPED_CHARS)
 
 
-def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> list[int]:
-    """Return the transcript line index each chapter starts at, monotonically."""
+def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> tuple[list[int], list[int]]:
+    """Transcript line index each chapter starts at, monotonically, plus the
+    indices of chapters whose title never matched well enough to trust.
+
+    The first chapter always starts at line 0 regardless of its title, since any
+    front matter ahead of it still belongs to that chapter's audio.
+    """
     starts: list[int] = []
+    weak: list[int] = []
     cursor = 0
-    for chapter in chapters:
+    for chapter_index, chapter in enumerate(chapters):
         target = normalize(chapter.title)
         window = lines[cursor:cursor + TITLE_SEARCH_WINDOW]
         best_score, best_index = -1.0, cursor
@@ -117,10 +125,16 @@ def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> list[int]
                 score = SequenceMatcher(None, target, joined).ratio()
                 if score > best_score:
                     best_score, best_index = score, cursor + offset
+        if best_score < MIN_TITLE_SCORE:
+            weak.append(chapter_index)
+            print(
+                f"  chapter {chapter_index} title matched weakly ({best_score:.2f}): {chapter.title[:48]}",
+                file=sys.stderr,
+            )
         starts.append(best_index)
         cursor = max(cursor, best_index + 1)
     starts[0] = 0
-    return starts
+    return starts, weak
 
 
 @lru_cache(maxsize=1)
@@ -129,6 +143,11 @@ def tagger():
     try:
         import MeCab
     except ImportError:
+        print(
+            "MeCab is unavailable; predicting duration from character counts, which "
+            "aligns kanji-dense lines noticeably worse. Install mecab-python3 + unidic-lite.",
+            file=sys.stderr,
+        )
         return None
     return MeCab.Tagger()
 
@@ -177,11 +196,15 @@ def align_segment(
     lines: list[str],
     silences: list[Silence],
     span: tuple[float, float],
-) -> list[tuple[float, float]]:
+) -> tuple[list[tuple[float, float]], bool]:
+    """Returns cue spans plus whether they came from proportional interpolation
+    rather than real silence boundaries. Interpolated spans look plausible and
+    cover the chapter evenly, so callers must report them instead of trusting them.
+    """
     span_start, span_end = span
     total = len(lines)
     if total == 1:
-        return [(span_start, span_end)]
+        return [(span_start, span_end)], False
 
     weights = [speech_weight(line) for line in lines]
     total_weight = sum(weights) or 1.0
@@ -190,20 +213,20 @@ def align_segment(
 
     inner = [s for s in silences if span_start < s.start and s.end < span_end]
     if len(inner) < total - 1:
-        return interpolate(predicted, span_start)
+        return interpolate(predicted, span_start), True
 
     cumulative, clock = [], span_start
     for duration in predicted[:-1]:
         clock += duration
         cumulative.append(clock)
-    band = max(BAND_MIN_SEC, available * BAND_SPAN_RATIO)
+    band = min(BAND_MAX_SEC, max(BAND_MIN_SEC, available * BAND_SPAN_RATIO))
 
     allowed = [
         [j for j, s in enumerate(inner) if abs(s.start - target) <= band]
         for target in cumulative
     ]
     if any(not candidates for candidates in allowed):
-        return interpolate(predicted, span_start)
+        return interpolate(predicted, span_start), True
 
     infinity = float("inf")
     best = [[infinity] * len(inner) for _ in range(total - 1)]
@@ -216,7 +239,10 @@ def align_segment(
         for j in allowed[step]:
             candidate_best, candidate_from = infinity, -1
             for k in allowed[step - 1]:
-                if best[step - 1][k] == infinity or k >= j:
+                # allowed[] is ascending, so nothing past this point can precede j.
+                if k >= j:
+                    break
+                if best[step - 1][k] == infinity:
                     continue
                 cost = best[step - 1][k] + line_cost(inner[j].start - inner[k].end, predicted[step])
                 if cost < candidate_best:
@@ -235,7 +261,7 @@ def align_segment(
         if cost < final_best:
             final_best, final_index = cost, j
     if final_index < 0:
-        return interpolate(predicted, span_start)
+        return interpolate(predicted, span_start), True
 
     chosen = [final_index]
     for step in range(last, 0, -1):
@@ -246,7 +272,7 @@ def align_segment(
     for step in range(1, total - 1):
         spans.append((inner[chosen[step - 1]].end, inner[chosen[step]].start))
     spans.append((inner[chosen[-1]].end, span_end))
-    return spans
+    return spans, False
 
 
 def trim_span(span: tuple[float, float], silences: list[Silence]) -> tuple[float, float]:
@@ -263,18 +289,24 @@ def build_cues(
     lines: list[str],
     chapters: list[Chapter],
     silences: list[Silence],
-) -> list[Cue]:
-    starts = match_chapter_starts(chapters, lines)
+) -> tuple[list[Cue], list[int], list[int]]:
+    """Cues for every line, plus the chapters that fell back to interpolation and
+    the chapters whose title match was too weak to anchor confidently."""
+    starts, weak_titles = match_chapter_starts(chapters, lines)
     bounds = starts + [len(lines)]
     cues: list[Cue] = []
+    interpolated: list[int] = []
     for chapter_index, chapter in enumerate(chapters):
         segment = lines[bounds[chapter_index]:bounds[chapter_index + 1]]
         if not segment:
             continue
         span = trim_span((chapter.start, chapter.end), silences)
-        for (start, end), text in zip(align_segment(segment, silences, span), segment):
+        spans, was_interpolated = align_segment(segment, silences, span)
+        if was_interpolated:
+            interpolated.append(chapter_index)
+        for (start, end), text in zip(spans, segment):
             cues.append(Cue(len(cues) + 1, start, end, text))
-    return cues
+    return cues, interpolated, weak_titles
 
 
 def timestamp(seconds: float) -> str:
@@ -303,6 +335,9 @@ def write_json(cues: list[Cue], path: Path) -> None:
 
 def report(cues: list[Cue], duration: float) -> None:
     rates = [speech_weight(c.text) / (c.end - c.start) for c in cues if c.end > c.start]
+    if not rates or duration <= 0:
+        print("no cues with a positive duration; nothing to report", file=sys.stderr)
+        return
     rates.sort()
     median = rates[len(rates) // 2]
     outliers = [r for r in rates if r < median * 0.5 or r > median * 2.0]
@@ -322,6 +357,12 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path)
     parser.add_argument("--noise-db", type=int, default=-40)
     parser.add_argument("--min-silence", type=float, default=0.15)
+    parser.add_argument(
+        "--max-interpolated-chapters",
+        type=int,
+        default=0,
+        help="how many chapters may fall back to proportional timings before the run fails",
+    )
     args = parser.parse_args()
 
     out_dir = args.out_dir or args.audio.parent
@@ -333,13 +374,44 @@ def main() -> int:
         return 1
 
     lines = read_lines(args.transcript)
+    if not lines:
+        print(f"{args.transcript} has no non-empty lines", file=sys.stderr)
+        return 1
+
+    # ffmpeg exits 0 when silencedetect simply matches nothing, so an unusable
+    # threshold or stream mapping would otherwise sail through as "no silences"
+    # and interpolate every chapter.
     silences = detect_silences(args.audio, args.noise_db, args.min_silence)
+    if len(silences) < len(lines) - 1:
+        print(
+            f"only {len(silences)} silences for {len(lines)} lines; alignment would be guesswork. "
+            f"Try a higher --noise-db than {args.noise_db} or a shorter --min-silence than {args.min_silence}.",
+            file=sys.stderr,
+        )
+        return 1
     print(f"chapters={len(chapters)} lines={len(lines)} silences={len(silences)}")
 
-    cues = build_cues(lines, chapters, silences)
+    cues, interpolated, weak_titles = build_cues(lines, chapters, silences)
+    report(cues, probe_duration(args.audio))
+    if weak_titles:
+        print(f"weak title matches: {len(weak_titles)} chapters (listed above)", file=sys.stderr)
+    if interpolated:
+        print(
+            f"interpolated chapters: {len(interpolated)} -> {interpolated[:10]}",
+            file=sys.stderr,
+        )
+    # Interpolated cues cover their chapter evenly, so they look healthy in the
+    # report while landing mid-speech. Refuse to leave them on disk unnoticed.
+    if len(interpolated) > args.max_interpolated_chapters or weak_titles:
+        print(
+            "alignment is not trustworthy; nothing written. Raise "
+            "--max-interpolated-chapters to accept it anyway.",
+            file=sys.stderr,
+        )
+        return 1
+
     write_srt(cues, out_dir / f"{args.audio.stem}.srt")
     write_json(cues, out_dir / f"{args.audio.stem}.timings.json")
-    report(cues, probe_duration(args.audio))
     print(f"wrote {out_dir / (args.audio.stem + '.srt')}")
     return 0
 

--- a/scripts/audio/align-transcript.py
+++ b/scripts/audio/align-transcript.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Align an audiobook transcript to its audio and emit SRT + JSON timings.
+
+Works without ASR: the transcript already matches the narration word for word,
+so timings come from three measured signals instead of a model -- the container
+chapter marks (exact anchors), ffmpeg silence detection (candidate boundaries),
+and mora count (relative duration within a chapter).
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from functools import lru_cache
+from pathlib import Path
+
+PAUSE_MARKS = "、,"
+DROPPED_CHARS = set("。「」『』（）()・！？!?…‥　 \t\r\n,、.")
+SMALL_KANA = set("ャュョァィゥェォヮゃゅょぁぃぅぇぉゎ")
+COMMA_MORA_EQUIV = 2.5
+SHORT_PAUSE_SEC = 0.75
+PAUSE_PENALTY_WEIGHT = 4.0
+BAND_MIN_SEC = 8.0
+BAND_SPAN_RATIO = 0.3
+TITLE_MATCH_SPANS = (1, 2, 3)
+TITLE_SEARCH_WINDOW = 90
+SPOKEN_FORMS = {"content": "コンテンツ"}
+
+
+@dataclass
+class Chapter:
+    start: float
+    end: float
+    title: str
+
+
+@dataclass
+class Silence:
+    start: float
+    end: float
+
+    @property
+    def duration(self) -> float:
+        return self.end - self.start
+
+
+@dataclass
+class Cue:
+    index: int
+    start: float
+    end: float
+    text: str
+
+
+def run(command: list[str]) -> str:
+    result = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    if result.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(command[:2])}\n{result.stderr[-2000:]}")
+    return result.stdout + result.stderr
+
+
+def probe_chapters(audio: Path) -> list[Chapter]:
+    raw = run(["ffprobe", "-v", "error", "-print_format", "json", "-show_chapters", str(audio)])
+    payload = json.loads(raw[raw.index("{"):])
+    return [
+        Chapter(float(c["start_time"]), float(c["end_time"]), c.get("tags", {}).get("title", ""))
+        for c in payload["chapters"]
+    ]
+
+
+def probe_duration(audio: Path) -> float:
+    raw = run([
+        "ffprobe", "-v", "error", "-show_entries", "format=duration",
+        "-of", "default=nw=1:nk=1", str(audio),
+    ])
+    return float(raw.strip().splitlines()[0])
+
+
+def detect_silences(audio: Path, noise_db: int, min_silence: float) -> list[Silence]:
+    raw = run([
+        "ffmpeg", "-hide_banner", "-nostats", "-i", str(audio), "-map", "0:a:0",
+        "-af", f"silencedetect=noise={noise_db}dB:d={min_silence}", "-f", "null", "-",
+    ])
+    starts = [float(m) for m in re.findall(r"silence_start: ([0-9.]+)", raw)]
+    ends = [float(m) for m in re.findall(r"silence_end: ([0-9.]+)", raw)]
+    return [Silence(s, e) for s, e in zip(starts, ends)]
+
+
+def read_lines(transcript: Path) -> list[str]:
+    text = transcript.read_text(encoding="utf-8")
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def normalize(text: str) -> str:
+    folded = unicodedata.normalize("NFKC", text).lower()
+    for written, spoken in SPOKEN_FORMS.items():
+        folded = folded.replace(written, spoken)
+    folded = re.sub(r"\b0+(\d)", r"\1", folded)
+    return "".join(ch for ch in folded if ch not in DROPPED_CHARS)
+
+
+def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> list[int]:
+    """Return the transcript line index each chapter starts at, monotonically."""
+    starts: list[int] = []
+    cursor = 0
+    for chapter in chapters:
+        target = normalize(chapter.title)
+        window = lines[cursor:cursor + TITLE_SEARCH_WINDOW]
+        best_score, best_index = -1.0, cursor
+        for offset in range(len(window)):
+            for span in TITLE_MATCH_SPANS:
+                joined = normalize("".join(window[offset:offset + span]))
+                score = SequenceMatcher(None, target, joined).ratio()
+                if score > best_score:
+                    best_score, best_index = score, cursor + offset
+        starts.append(best_index)
+        cursor = max(cursor, best_index + 1)
+    starts[0] = 0
+    return starts
+
+
+@lru_cache(maxsize=1)
+def tagger():
+    """MeCab reading tagger, or None when unavailable (falls back to character count)."""
+    try:
+        import MeCab
+    except ImportError:
+        return None
+    return MeCab.Tagger()
+
+
+def count_mora(reading: str) -> int:
+    return sum(1 for ch in reading if ch not in SMALL_KANA and ch not in DROPPED_CHARS)
+
+
+@lru_cache(maxsize=4096)
+def speech_weight(line: str) -> float:
+    """Relative time a line takes to narrate, in mora-equivalents."""
+    pauses = sum(1 for ch in line if ch in PAUSE_MARKS)
+    parser = tagger()
+    if parser is None:
+        return sum(1 for ch in line if ch not in DROPPED_CHARS) + pauses * COMMA_MORA_EQUIV
+
+    mora = 0
+    for token in parser.parse(line).splitlines():
+        if token == "EOS" or not token.strip():
+            continue
+        fields = token.split("\t")
+        reading = fields[1] if len(fields) > 1 and fields[1] else fields[0]
+        mora += count_mora(reading)
+    return mora + pauses * COMMA_MORA_EQUIV
+
+
+def line_cost(actual: float, predicted: float) -> float:
+    if actual <= 0:
+        return float("inf")
+    return (actual - predicted) ** 2 / max(predicted, 0.5)
+
+
+def pause_cost(silence: Silence) -> float:
+    return max(0.0, SHORT_PAUSE_SEC - silence.duration) * PAUSE_PENALTY_WEIGHT
+
+
+def interpolate(predicted: list[float], span_start: float) -> list[tuple[float, float]]:
+    spans, clock = [], span_start
+    for duration in predicted:
+        spans.append((clock, clock + duration))
+        clock += duration
+    return spans
+
+
+def align_segment(
+    lines: list[str],
+    silences: list[Silence],
+    span: tuple[float, float],
+) -> list[tuple[float, float]]:
+    span_start, span_end = span
+    total = len(lines)
+    if total == 1:
+        return [(span_start, span_end)]
+
+    weights = [speech_weight(line) for line in lines]
+    total_weight = sum(weights) or 1.0
+    available = max(span_end - span_start, 1e-6)
+    predicted = [w / total_weight * available for w in weights]
+
+    inner = [s for s in silences if span_start < s.start and s.end < span_end]
+    if len(inner) < total - 1:
+        return interpolate(predicted, span_start)
+
+    cumulative, clock = [], span_start
+    for duration in predicted[:-1]:
+        clock += duration
+        cumulative.append(clock)
+    band = max(BAND_MIN_SEC, available * BAND_SPAN_RATIO)
+
+    allowed = [
+        [j for j, s in enumerate(inner) if abs(s.start - target) <= band]
+        for target in cumulative
+    ]
+    if any(not candidates for candidates in allowed):
+        return interpolate(predicted, span_start)
+
+    infinity = float("inf")
+    best = [[infinity] * len(inner) for _ in range(total - 1)]
+    previous = [[-1] * len(inner) for _ in range(total - 1)]
+
+    for j in allowed[0]:
+        best[0][j] = line_cost(inner[j].start - span_start, predicted[0]) + pause_cost(inner[j])
+
+    for step in range(1, total - 1):
+        for j in allowed[step]:
+            candidate_best, candidate_from = infinity, -1
+            for k in allowed[step - 1]:
+                if best[step - 1][k] == infinity or k >= j:
+                    continue
+                cost = best[step - 1][k] + line_cost(inner[j].start - inner[k].end, predicted[step])
+                if cost < candidate_best:
+                    candidate_best, candidate_from = cost, k
+            if candidate_from < 0:
+                continue
+            best[step][j] = candidate_best + pause_cost(inner[j])
+            previous[step][j] = candidate_from
+
+    last = total - 2
+    final_best, final_index = infinity, -1
+    for j in allowed[last]:
+        if best[last][j] == infinity:
+            continue
+        cost = best[last][j] + line_cost(span_end - inner[j].end, predicted[-1])
+        if cost < final_best:
+            final_best, final_index = cost, j
+    if final_index < 0:
+        return interpolate(predicted, span_start)
+
+    chosen = [final_index]
+    for step in range(last, 0, -1):
+        chosen.append(previous[step][chosen[-1]])
+    chosen.reverse()
+
+    spans = [(span_start, inner[chosen[0]].start)]
+    for step in range(1, total - 1):
+        spans.append((inner[chosen[step - 1]].end, inner[chosen[step]].start))
+    spans.append((inner[chosen[-1]].end, span_end))
+    return spans
+
+
+def trim_span(span: tuple[float, float], silences: list[Silence]) -> tuple[float, float]:
+    start, end = span
+    for silence in silences:
+        if silence.start <= start + 0.05 < silence.end < end:
+            start = silence.end
+        if start < silence.start < end <= silence.end + 0.05:
+            end = silence.start
+    return (start, end)
+
+
+def build_cues(
+    lines: list[str],
+    chapters: list[Chapter],
+    silences: list[Silence],
+) -> list[Cue]:
+    starts = match_chapter_starts(chapters, lines)
+    bounds = starts + [len(lines)]
+    cues: list[Cue] = []
+    for chapter_index, chapter in enumerate(chapters):
+        segment = lines[bounds[chapter_index]:bounds[chapter_index + 1]]
+        if not segment:
+            continue
+        span = trim_span((chapter.start, chapter.end), silences)
+        for (start, end), text in zip(align_segment(segment, silences, span), segment):
+            cues.append(Cue(len(cues) + 1, start, end, text))
+    return cues
+
+
+def timestamp(seconds: float) -> str:
+    millis = max(0, round(seconds * 1000))
+    hours, millis = divmod(millis, 3_600_000)
+    minutes, millis = divmod(millis, 60_000)
+    secs, millis = divmod(millis, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def write_srt(cues: list[Cue], path: Path) -> None:
+    blocks = [
+        f"{cue.index}\n{timestamp(cue.start)} --> {timestamp(cue.end)}\n{cue.text}\n"
+        for cue in cues
+    ]
+    path.write_text("\n".join(blocks), encoding="utf-8")
+
+
+def write_json(cues: list[Cue], path: Path) -> None:
+    payload = [
+        {"index": cue.index, "start": round(cue.start, 3), "end": round(cue.end, 3), "text": cue.text}
+        for cue in cues
+    ]
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def report(cues: list[Cue], duration: float) -> None:
+    rates = [speech_weight(c.text) / (c.end - c.start) for c in cues if c.end > c.start]
+    rates.sort()
+    median = rates[len(rates) // 2]
+    outliers = [r for r in rates if r < median * 0.5 or r > median * 2.0]
+    covered = sum(c.end - c.start for c in cues)
+    print(f"cues:            {len(cues)}")
+    print(f"audio duration:  {duration:.1f}s")
+    print(f"covered:         {covered:.1f}s ({covered / duration * 100:.1f}%)")
+    print(f"median rate:     {median:.2f} mora/s")
+    print(f"rate p05..p95:   {rates[len(rates) // 20]:.2f} .. {rates[-len(rates) // 20]:.2f}")
+    print(f"rate outliers:   {len(outliers)} ({len(outliers) / len(rates) * 100:.1f}%)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audio", type=Path)
+    parser.add_argument("transcript", type=Path)
+    parser.add_argument("--out-dir", type=Path)
+    parser.add_argument("--noise-db", type=int, default=-40)
+    parser.add_argument("--min-silence", type=float, default=0.15)
+    args = parser.parse_args()
+
+    out_dir = args.out_dir or args.audio.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    chapters = probe_chapters(args.audio)
+    if not chapters:
+        print("no chapters found in container; cannot anchor alignment", file=sys.stderr)
+        return 1
+
+    lines = read_lines(args.transcript)
+    silences = detect_silences(args.audio, args.noise_db, args.min_silence)
+    print(f"chapters={len(chapters)} lines={len(lines)} silences={len(silences)}")
+
+    cues = build_cues(lines, chapters, silences)
+    write_srt(cues, out_dir / f"{args.audio.stem}.srt")
+    write_json(cues, out_dir / f"{args.audio.stem}.timings.json")
+    report(cues, probe_duration(args.audio))
+    print(f"wrote {out_dir / (args.audio.stem + '.srt')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audio/align-transcript.py
+++ b/scripts/audio/align-transcript.py
@@ -59,7 +59,10 @@ class Cue:
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    except FileNotFoundError as missing:
+        raise RuntimeError(f"{command[0]} is not on PATH; install ffmpeg") from missing
     if result.returncode != 0:
         raise RuntimeError(f"command failed: {' '.join(command[:2])}\n{result.stderr[-2000:]}")
     return result
@@ -72,7 +75,7 @@ def probe_chapters(audio: Path) -> list[Chapter]:
     payload = json.loads(raw)
     return [
         Chapter(float(c["start_time"]), float(c["end_time"]), c.get("tags", {}).get("title", ""))
-        for c in payload["chapters"]
+        for c in payload.get("chapters", [])
     ]
 
 
@@ -135,7 +138,9 @@ def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> tuple[lis
                 if score > best_score:
                     best_score, best_index = score, cursor + offset
         starts.append(best_index)
-        cursor = max(cursor, best_index + 1)
+        # A weak match must not move the search window for the chapters after it.
+        if best_score >= MIN_TITLE_SCORE:
+            cursor = max(cursor, best_index + 1)
         # Chapter 0 starts at line 0 no matter what its title says, so a weak
         # match there costs nothing.
         if chapter_index == 0 or best_score >= MIN_TITLE_SCORE:

--- a/scripts/audio/align-transcript.py
+++ b/scripts/audio/align-transcript.py
@@ -137,13 +137,16 @@ def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> tuple[lis
                 score = SequenceMatcher(None, target, joined).ratio() if target and joined else 0.0
                 if score > best_score:
                     best_score, best_index = score, cursor + offset
-        starts.append(best_index)
-        # A weak match must not move the search window for the chapters after it.
-        if best_score >= MIN_TITLE_SCORE:
+        # Anchoring to an untrusted index can place a chapter behind its
+        # predecessor, which makes build_cues emit some lines twice and drop
+        # others. Falling back to the cursor keeps starts non-decreasing.
+        trusted = best_score >= MIN_TITLE_SCORE
+        starts.append(best_index if trusted else cursor)
+        if trusted:
             cursor = max(cursor, best_index + 1)
         # Chapter 0 starts at line 0 no matter what its title says, so a weak
         # match there costs nothing.
-        if chapter_index == 0 or best_score >= MIN_TITLE_SCORE:
+        if trusted or chapter_index == 0:
             continue
         weak.append(chapter_index)
         print(
@@ -425,6 +428,15 @@ def main() -> int:
     print(f"chapters={len(chapters)} lines={len(lines)} silences={len(silences)}")
 
     cues, interpolated, weak_titles = build_cues(lines, chapters, silences, band_max=args.band_max)
+    # build-narration.ts pairs cues to lines by position, so anything other than
+    # one cue per line means chapter bounds overlapped and the mapping is garbage.
+    if len(cues) != len(lines):
+        print(
+            f"produced {len(cues)} cues for {len(lines)} lines; chapter bounds are not monotonic",
+            file=sys.stderr,
+        )
+        return 1
+
     report(cues, probe_duration(args.audio))
 
     # Interpolated cues cover their chapter evenly, so they look healthy in the

--- a/scripts/audio/align-transcript.py
+++ b/scripts/audio/align-transcript.py
@@ -58,16 +58,18 @@ class Cue:
     text: str
 
 
-def run(command: list[str]) -> str:
+def run(command: list[str]) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode != 0:
         raise RuntimeError(f"command failed: {' '.join(command[:2])}\n{result.stderr[-2000:]}")
-    return result.stdout + result.stderr
+    return result
 
 
 def probe_chapters(audio: Path) -> list[Chapter]:
-    raw = run(["ffprobe", "-v", "error", "-print_format", "json", "-show_chapters", str(audio)])
-    payload = json.loads(raw[raw.index("{"):])
+    # stdout only: ffprobe can emit warnings while still exiting 0, and mixing them
+    # into the payload turns valid output into a JSON decode error.
+    raw = run(["ffprobe", "-v", "error", "-print_format", "json", "-show_chapters", str(audio)]).stdout
+    payload = json.loads(raw)
     return [
         Chapter(float(c["start_time"]), float(c["end_time"]), c.get("tags", {}).get("title", ""))
         for c in payload["chapters"]
@@ -78,17 +80,22 @@ def probe_duration(audio: Path) -> float:
     raw = run([
         "ffprobe", "-v", "error", "-show_entries", "format=duration",
         "-of", "default=nw=1:nk=1", str(audio),
-    ])
-    return float(raw.strip().splitlines()[0])
+    ]).stdout.strip()
+    try:
+        return float(raw.splitlines()[0])
+    except (IndexError, ValueError):
+        return 0.0
 
 
 def detect_silences(audio: Path, noise_db: int, min_silence: float) -> list[Silence]:
-    raw = run([
+    # silencedetect reports on stderr, so this one genuinely needs both streams.
+    result = run([
         "ffmpeg", "-hide_banner", "-nostats", "-i", str(audio), "-map", "0:a:0",
         "-af", f"silencedetect=noise={noise_db}dB:d={min_silence}", "-f", "null", "-",
     ])
-    starts = [float(m) for m in re.findall(r"silence_start: ([0-9.]+)", raw)]
-    ends = [float(m) for m in re.findall(r"silence_end: ([0-9.]+)", raw)]
+    raw = result.stdout + result.stderr
+    starts = [float(m) for m in re.findall(r"silence_start: (-?[0-9.]+)", raw)]
+    ends = [float(m) for m in re.findall(r"silence_end: (-?[0-9.]+)", raw)]
     return [Silence(s, e) for s, e in zip(starts, ends)]
 
 
@@ -122,17 +129,22 @@ def match_chapter_starts(chapters: list[Chapter], lines: list[str]) -> tuple[lis
         for offset in range(len(window)):
             for span in TITLE_MATCH_SPANS:
                 joined = normalize("".join(window[offset:offset + span]))
-                score = SequenceMatcher(None, target, joined).ratio()
+                # Two empty strings score a perfect 1.0, so an untitled chapter
+                # would otherwise anchor to the first punctuation-only line.
+                score = SequenceMatcher(None, target, joined).ratio() if target and joined else 0.0
                 if score > best_score:
                     best_score, best_index = score, cursor + offset
-        if best_score < MIN_TITLE_SCORE:
-            weak.append(chapter_index)
-            print(
-                f"  chapter {chapter_index} title matched weakly ({best_score:.2f}): {chapter.title[:48]}",
-                file=sys.stderr,
-            )
         starts.append(best_index)
         cursor = max(cursor, best_index + 1)
+        # Chapter 0 starts at line 0 no matter what its title says, so a weak
+        # match there costs nothing.
+        if chapter_index == 0 or best_score >= MIN_TITLE_SCORE:
+            continue
+        weak.append(chapter_index)
+        print(
+            f"  chapter {chapter_index} title matched weakly ({best_score:.2f}): {chapter.title[:48]}",
+            file=sys.stderr,
+        )
     starts[0] = 0
     return starts, weak
 
@@ -196,6 +208,8 @@ def align_segment(
     lines: list[str],
     silences: list[Silence],
     span: tuple[float, float],
+    *,
+    band_max: float = BAND_MAX_SEC,
 ) -> tuple[list[tuple[float, float]], bool]:
     """Returns cue spans plus whether they came from proportional interpolation
     rather than real silence boundaries. Interpolated spans look plausible and
@@ -219,7 +233,7 @@ def align_segment(
     for duration in predicted[:-1]:
         clock += duration
         cumulative.append(clock)
-    band = min(BAND_MAX_SEC, max(BAND_MIN_SEC, available * BAND_SPAN_RATIO))
+    band = min(band_max, max(BAND_MIN_SEC, available * BAND_SPAN_RATIO))
 
     allowed = [
         [j for j, s in enumerate(inner) if abs(s.start - target) <= band]
@@ -289,6 +303,8 @@ def build_cues(
     lines: list[str],
     chapters: list[Chapter],
     silences: list[Silence],
+    *,
+    band_max: float = BAND_MAX_SEC,
 ) -> tuple[list[Cue], list[int], list[int]]:
     """Cues for every line, plus the chapters that fell back to interpolation and
     the chapters whose title match was too weak to anchor confidently."""
@@ -301,7 +317,7 @@ def build_cues(
         if not segment:
             continue
         span = trim_span((chapter.start, chapter.end), silences)
-        spans, was_interpolated = align_segment(segment, silences, span)
+        spans, was_interpolated = align_segment(segment, silences, span, band_max=band_max)
         if was_interpolated:
             interpolated.append(chapter_index)
         for (start, end), text in zip(spans, segment):
@@ -363,6 +379,18 @@ def main() -> int:
         default=0,
         help="how many chapters may fall back to proportional timings before the run fails",
     )
+    parser.add_argument(
+        "--max-weak-titles",
+        type=int,
+        default=0,
+        help="how many chapter titles may match the transcript poorly before the run fails",
+    )
+    parser.add_argument(
+        "--band-max",
+        type=float,
+        default=BAND_MAX_SEC,
+        help="widest search window around a predicted boundary; raise it for long chapters",
+    )
     args = parser.parse_args()
 
     out_dir = args.out_dir or args.audio.parent
@@ -391,21 +419,21 @@ def main() -> int:
         return 1
     print(f"chapters={len(chapters)} lines={len(lines)} silences={len(silences)}")
 
-    cues, interpolated, weak_titles = build_cues(lines, chapters, silences)
+    cues, interpolated, weak_titles = build_cues(lines, chapters, silences, band_max=args.band_max)
     report(cues, probe_duration(args.audio))
-    if weak_titles:
-        print(f"weak title matches: {len(weak_titles)} chapters (listed above)", file=sys.stderr)
-    if interpolated:
-        print(
-            f"interpolated chapters: {len(interpolated)} -> {interpolated[:10]}",
-            file=sys.stderr,
-        )
+
     # Interpolated cues cover their chapter evenly, so they look healthy in the
-    # report while landing mid-speech. Refuse to leave them on disk unnoticed.
-    if len(interpolated) > args.max_interpolated_chapters or weak_titles:
+    # report while landing mid-speech. Refuse to leave either kind on disk unseen.
+    failures = []
+    if len(interpolated) > args.max_interpolated_chapters:
+        print(f"interpolated chapters: {len(interpolated)} -> {interpolated[:10]}", file=sys.stderr)
+        failures.append(f"--max-interpolated-chapters (currently {args.max_interpolated_chapters})")
+    if len(weak_titles) > args.max_weak_titles:
+        print(f"weak title matches: {len(weak_titles)} -> {weak_titles[:10]}", file=sys.stderr)
+        failures.append(f"--max-weak-titles (currently {args.max_weak_titles})")
+    if failures:
         print(
-            "alignment is not trustworthy; nothing written. Raise "
-            "--max-interpolated-chapters to accept it anyway.",
+            f"alignment is not trustworthy; nothing written. Raise {' or '.join(failures)} to accept it anyway.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/audio/build-narration.ts
+++ b/scripts/audio/build-narration.ts
@@ -56,7 +56,7 @@ function similarity(left: string, right: string): number {
   return (2 * shared) / totalGrams;
 }
 
-/** Same barricade the reader applies, so a truncated timings file fails loudly. */
+/** Validates the aligner's output up front, so a truncated file fails loudly. */
 function parseTimings(raw: string, path: string): TimingCue[] {
   const parsed: unknown = JSON.parse(raw);
   if (!Array.isArray(parsed) || parsed.length === 0) {
@@ -158,7 +158,14 @@ function main(): void {
   console.log(`cues:     ${cues.length}`);
   console.log(`covered:  ${covered} (${(coverage * 100).toFixed(1)}%)`);
 
-  const minCoverage = parseFloat(readArg('min-coverage') ?? `${DEFAULT_MIN_COVERAGE}`);
+  const minCoverageArg = readArg('min-coverage');
+  const minCoverage = minCoverageArg === null ? DEFAULT_MIN_COVERAGE : Number(minCoverageArg);
+  // NaN would make every comparison false and silently disable the gate this flag
+  // exists to tune, so a typo has to fail rather than wave the manifest through.
+  if (!isFinite(minCoverage) || minCoverage < 0 || minCoverage > 1) {
+    console.error(`--min-coverage must be a number between 0 and 1, got "${minCoverageArg}".`);
+    process.exit(1);
+  }
   if (coverage < minCoverage) {
     console.error(
       `Coverage ${(coverage * 100).toFixed(1)}% is below ${(minCoverage * 100).toFixed(1)}%. ` +

--- a/scripts/audio/build-narration.ts
+++ b/scripts/audio/build-narration.ts
@@ -6,12 +6,8 @@
  * plays PlayableUnits, so this maps one onto the other and writes the manifest
  * the reader fetches, with null for any unit the recording does not cover.
  *
- * Usage:
- *   npx tsx scripts/audio/build-narration.ts \
- *     --timings "<book>.timings.json" \
- *     --text "public/bookv2-furigana/<book>/<book>-rephrase-furigana.txt" \
- *     --audio-url "https://cdn.example.com/<book>.m4a" \
- *     --out "public/bookv2-furigana/<book>.narration.json"
+ * Flags are listed by --help; see scripts/README.md for the full workflow, the
+ * manifest path the reader expects, and why --text must match the synced text.
  */
 
 import * as fs from 'fs';
@@ -28,6 +24,7 @@ interface TimingCue {
 const SEARCH_WINDOW = 12;
 const MAX_SPAN_LENGTH_RATIO = 1.6;
 const MIN_SCORE = 0.6;
+const DEFAULT_MIN_COVERAGE = 0.9;
 const DROPPED_PATTERN = /[\s。、「」『』（）()・！？!?…‥,.]/g;
 
 function normalize(text: string): string {
@@ -47,13 +44,37 @@ function bigrams(text: string): Map<string, number> {
 function similarity(left: string, right: string): number {
   if (!left || !right) return 0;
   if (left === right) return 1;
+  // Single characters have no bigrams, so fall back to equality above.
+  const totalGrams = left.length - 1 + right.length - 1;
+  if (totalGrams <= 0) return 0;
   const leftGrams = bigrams(left);
   const rightGrams = bigrams(right);
   let shared = 0;
   for (const [gram, count] of leftGrams) {
     shared += Math.min(count, rightGrams.get(gram) ?? 0);
   }
-  return (2 * shared) / (left.length - 1 + right.length - 1);
+  return (2 * shared) / totalGrams;
+}
+
+/** Same barricade the reader applies, so a truncated timings file fails loudly. */
+function parseTimings(raw: string, path: string): TimingCue[] {
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    console.error(`${path} is not a non-empty array of cues.`);
+    process.exit(1);
+  }
+  return parsed.map((entry, index) => {
+    const { start, end, text } = (entry ?? {}) as Record<string, unknown>;
+    if (typeof start !== 'number' || typeof end !== 'number' || !isFinite(start) || !isFinite(end)) {
+      console.error(`${path} cue ${index} has no finite start/end.`);
+      process.exit(1);
+    }
+    if (typeof text !== 'string') {
+      console.error(`${path} cue ${index} has no text.`);
+      process.exit(1);
+    }
+    return { start, end, text };
+  });
 }
 
 function readArg(name: string): string | null {
@@ -92,11 +113,15 @@ function matchCues(unitTexts: string[], cues: TimingCue[]): (NarrationCue | null
       }
     }
 
-    if (bestFrom < 0 || bestScore < MIN_SCORE) {
+    const start = bestFrom < 0 ? 0 : cues[bestFrom].start;
+    const end = bestFrom < 0 ? 0 : cues[bestFrom + bestSpan - 1].end;
+    // The reader rejects non-positive spans, so never emit one it would silently
+    // drop while this script still counted it as covered.
+    if (bestFrom < 0 || bestScore < MIN_SCORE || end <= start) {
       matched.push(null);
       continue;
     }
-    matched.push({ start: cues[bestFrom].start, end: cues[bestFrom + bestSpan - 1].end });
+    matched.push({ start, end });
     cursor = bestFrom + bestSpan;
   }
 
@@ -110,25 +135,42 @@ function main(): void {
   const outPath = readArg('out');
 
   if (!timingsPath || !textPath || !audioUrl || !outPath) {
-    console.error('Usage: --timings <file> --text <file> --audio-url <url> --out <file>');
+    console.error('Usage: --timings <file> --text <file> --audio-url <url> --out <file> [--min-coverage <0-1>]');
     process.exit(1);
   }
 
-  const cues: TimingCue[] = JSON.parse(fs.readFileSync(timingsPath, 'utf8'));
-  // The reader parses paragraphs out of LF text, so CRLF source files would
-  // otherwise collapse into a single unit.
+  const cues = parseTimings(fs.readFileSync(timingsPath, 'utf8'), timingsPath);
+  // The plain/furigana reader splits paragraphs on a blank LF line, so a CRLF
+  // source would collapse into a single unit there. Rephrase text splits on any
+  // newline and is unaffected, but both formats are accepted here.
   const content = fs.readFileSync(textPath, 'utf8').replace(/\r\n/g, '\n');
   const units = buildPlayableUnits(content);
+  if (units.length === 0) {
+    console.error(`No reader units parsed from ${textPath}; refusing to write a manifest.`);
+    process.exit(1);
+  }
+
   const matched = matchCues(units.map((unit) => normalize(unit.main)), cues);
-
-  const manifest: NarrationManifest = { audioUrl, cues: matched };
-  fs.writeFileSync(outPath, JSON.stringify(manifest), 'utf8');
-
   const covered = matched.filter(Boolean).length;
-  console.log(`units:   ${units.length}`);
-  console.log(`cues:    ${cues.length}`);
-  console.log(`covered: ${covered} (${((covered / units.length) * 100).toFixed(1)}%)`);
-  console.log(`wrote    ${outPath}`);
+  const coverage = covered / units.length;
+
+  console.log(`units:    ${units.length}`);
+  console.log(`cues:     ${cues.length}`);
+  console.log(`covered:  ${covered} (${(coverage * 100).toFixed(1)}%)`);
+
+  const minCoverage = parseFloat(readArg('min-coverage') ?? `${DEFAULT_MIN_COVERAGE}`);
+  if (coverage < minCoverage) {
+    console.error(
+      `Coverage ${(coverage * 100).toFixed(1)}% is below ${(minCoverage * 100).toFixed(1)}%. ` +
+      'This usually means --text is not the text the transcript was aligned against. ' +
+      'Pass --min-coverage to accept it anyway.'
+    );
+    process.exit(1);
+  }
+
+  const manifest: NarrationManifest = { audioUrl, unitCount: units.length, cues: matched };
+  fs.writeFileSync(outPath, JSON.stringify(manifest), 'utf8');
+  console.log(`wrote     ${outPath}`);
 }
 
 main();

--- a/scripts/audio/build-narration.ts
+++ b/scripts/audio/build-narration.ts
@@ -80,7 +80,14 @@ function parseTimings(raw: string, path: string): TimingCue[] {
 function readArg(name: string): string | null {
   const index = process.argv.indexOf(`--${name}`);
   if (index === -1 || index + 1 >= process.argv.length) return null;
-  return process.argv[index + 1];
+  const value = process.argv[index + 1];
+  // Swallowing the next flag as a value turns a missing argument into a plausible
+  // wrong one, e.g. --audio-url --out x yielding an audioUrl of "--out".
+  if (value.startsWith('--')) {
+    console.error(`--${name} needs a value, found "${value}".`);
+    process.exit(1);
+  }
+  return value;
 }
 
 function matchCues(unitTexts: string[], cues: TimingCue[]): (NarrationCue | null)[] {

--- a/scripts/audio/build-narration.ts
+++ b/scripts/audio/build-narration.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env npx tsx
+/**
+ * Build a narration manifest from aligned audiobook timings.
+ *
+ * align-transcript.py emits cues keyed by transcript line. The reader instead
+ * plays PlayableUnits, so this maps one onto the other and writes the manifest
+ * the reader fetches, with null for any unit the recording does not cover.
+ *
+ * Usage:
+ *   npx tsx scripts/audio/build-narration.ts \
+ *     --timings "<book>.timings.json" \
+ *     --text "public/bookv2-furigana/<book>/<book>-rephrase-furigana.txt" \
+ *     --audio-url "https://cdn.example.com/<book>.m4a" \
+ *     --out "public/bookv2-furigana/<book>.narration.json"
+ */
+
+import * as fs from 'fs';
+import { buildPlayableUnits } from '@/lib/utils/buildPlayableUnits';
+import { stripFurigana } from '@/lib/utils/furiganaParser';
+import type { NarrationCue, NarrationManifest } from '@/lib/types';
+
+interface TimingCue {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const SEARCH_WINDOW = 12;
+const MAX_SPAN_LENGTH_RATIO = 1.6;
+const MIN_SCORE = 0.6;
+const DROPPED_PATTERN = /[\s。、「」『』（）()・！？!?…‥,.]/g;
+
+function normalize(text: string): string {
+  return stripFurigana(text).normalize('NFKC').replace(DROPPED_PATTERN, '');
+}
+
+function bigrams(text: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let i = 0; i < text.length - 1; i++) {
+    const gram = text.slice(i, i + 2);
+    counts.set(gram, (counts.get(gram) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Dice coefficient over character bigrams: order-aware enough, cheap, and no deps. */
+function similarity(left: string, right: string): number {
+  if (!left || !right) return 0;
+  if (left === right) return 1;
+  const leftGrams = bigrams(left);
+  const rightGrams = bigrams(right);
+  let shared = 0;
+  for (const [gram, count] of leftGrams) {
+    shared += Math.min(count, rightGrams.get(gram) ?? 0);
+  }
+  return (2 * shared) / (left.length - 1 + right.length - 1);
+}
+
+function readArg(name: string): string | null {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1 || index + 1 >= process.argv.length) return null;
+  return process.argv[index + 1];
+}
+
+function matchCues(unitTexts: string[], cues: TimingCue[]): (NarrationCue | null)[] {
+  const cueTexts = cues.map((cue) => normalize(cue.text));
+  const matched: (NarrationCue | null)[] = [];
+  let cursor = 0;
+
+  for (const unitText of unitTexts) {
+    if (!unitText) {
+      matched.push(null);
+      continue;
+    }
+
+    let bestScore = 0;
+    let bestFrom = -1;
+    let bestSpan = 1;
+    // A unit can cover several cues when the reader merges lines the transcript
+    // kept apart, so the span grows until it overshoots the unit's own length.
+    for (let offset = 0; offset < SEARCH_WINDOW && cursor + offset < cues.length; offset++) {
+      let joined = '';
+      for (let span = 1; cursor + offset + span <= cues.length; span++) {
+        joined += cueTexts[cursor + offset + span - 1];
+        const score = similarity(unitText, joined);
+        if (score > bestScore) {
+          bestScore = score;
+          bestFrom = cursor + offset;
+          bestSpan = span;
+        }
+        if (joined.length >= unitText.length * MAX_SPAN_LENGTH_RATIO) break;
+      }
+    }
+
+    if (bestFrom < 0 || bestScore < MIN_SCORE) {
+      matched.push(null);
+      continue;
+    }
+    matched.push({ start: cues[bestFrom].start, end: cues[bestFrom + bestSpan - 1].end });
+    cursor = bestFrom + bestSpan;
+  }
+
+  return matched;
+}
+
+function main(): void {
+  const timingsPath = readArg('timings');
+  const textPath = readArg('text');
+  const audioUrl = readArg('audio-url');
+  const outPath = readArg('out');
+
+  if (!timingsPath || !textPath || !audioUrl || !outPath) {
+    console.error('Usage: --timings <file> --text <file> --audio-url <url> --out <file>');
+    process.exit(1);
+  }
+
+  const cues: TimingCue[] = JSON.parse(fs.readFileSync(timingsPath, 'utf8'));
+  // The reader parses paragraphs out of LF text, so CRLF source files would
+  // otherwise collapse into a single unit.
+  const content = fs.readFileSync(textPath, 'utf8').replace(/\r\n/g, '\n');
+  const units = buildPlayableUnits(content);
+  const matched = matchCues(units.map((unit) => normalize(unit.main)), cues);
+
+  const manifest: NarrationManifest = { audioUrl, cues: matched };
+  fs.writeFileSync(outPath, JSON.stringify(manifest), 'utf8');
+
+  const covered = matched.filter(Boolean).length;
+  console.log(`units:   ${units.length}`);
+  console.log(`cues:    ${cues.length}`);
+  console.log(`covered: ${covered} (${((covered / units.length) * 100).toFixed(1)}%)`);
+  console.log(`wrote    ${outPath}`);
+}
+
+main();


### PR DESCRIPTION
## What

The reader's audiobook player currently synthesises every sentence with Google TTS.
When a book has an actual narration recording, this makes the play button use that
recording instead - same player bar, same keyboard controls, same speed slider.

A book opts in by having a `<book>.narration.json` sidecar next to its metadata JSON.
No manifest means nothing changes: playback stays on TTS.

## How

**Playback.** `useAudioBook` keeps one `<audio>` element for the whole recording
instead of building a fresh clip per sentence. Playing a unit seeks to its cue start
and stops at its cue end. The element is deliberately never given a new `src` between
sentences, so the recording is fetched once and the browser serves each seek from its
buffer via range requests.

Cue ends land where the narrator pauses, so `timeupdate` (which only fires a few times
a second) is precise enough - the overshoot falls in silence rather than the next line.

Failures are handled differently from TTS on purpose: a bad TTS clip is transient and
worth skipping, but a broken recording is a whole-file problem, so narration stops
rather than skipping through the book.

**Alignment.** `scripts/audio/align-transcript.py` produces the cues without ASR:

- container chapter marks give exact anchors, so drift resets every chapter
- ffmpeg `silencedetect` supplies candidate boundaries
- MeCab mora counts predict relative duration within a chapter
- a DP picks the boundaries chapter by chapter

On the book this was built against (2h28m, 103 chapters, 1151 lines) every chapter
aligned via the DP with no interpolation fallback, boundary gaps sat at a 0.84s median
(the narrator's sentence pause), and the mora/s p05..p95 came in at 6.34..8.42 around a
7.67 median. About 2.4% of cues are loose, all inside one stretch where the transcript
is phrase-broken rather than sentence-broken.

`scripts/audio/build-narration.ts` then maps those cues onto `PlayableUnit` indices by
importing the reader's own `buildPlayableUnits`, so the manifest cannot drift from what
the reader actually renders.

## Notes

- `sub` (rephrased) text has no recording and stays on TTS, including in `both` mode.
  The player bar shows a `Narration` label only when the recording is what you'll hear.
- Units the recording doesn't cover are `null` in the manifest and fall back to TTS,
  so partial coverage works.
- Audio is not served from `public/` - it's too large for the Lambda bundle. The
  manifest carries an absolute URL, so host it wherever.
- First commit is a pure refactor: the sidecar path logic was duplicated between the
  metadata hook and the new narration hook, so it moved into `bookAssetPath`.

## Verification

`npx tsc --noEmit`, `npx eslint`, and `npm run build` all pass. The one remaining lint
warning in `useAudioBook.ts` is pre-existing (confirmed against the base branch).

Playback itself has not been exercised in a browser yet - no book has a manifest
attached in this repo.